### PR TITLE
Upgrade node-sass to a version that supports Node 8.x

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -598,7 +598,12 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2", "bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
+  version "2.0.7"
+  uid "94d7146671b9719e00a09c29b01a691bc85048c2"
+  resolved "git+https://github.com/debris/bignumber.js#94d7146671b9719e00a09c29b01a691bc85048c2"
+
+"bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "lodash": "^3.10.1",
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.11",
-    "node-sass": "^4.3.0",
+    "node-sass": "^4.5.3",
     "pidusage": "^1.1.5",
     "postcss": "^5.2.11",
     "postcss-color-function": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5190,9 +5190,9 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@^4.3.0:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.1.tgz#e8e119fe3c8213ad7e56ca618dd231e9e8b30f5b"
+node-sass@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
When using Node 8.x, the following error was triggered when starting `yarn run dev`:
```
>> Error: Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (57)
>> For more information on which environments are supported please see:
>> https://github.com/sass/node-sass/releases/tag/v4.5.1
```

This is due to packaged `node-sass` supporting Node runtime up to 7.x only (support for Node 8.x was [introduced in `node-sass 4.5.3`](https://github.com/sass/node-sass/pull/1969)).

This PR just bumps the `node-sass` version to let us use Ganache with Node 8.x 🍾 