### PR TITLE
Fix a path to contract.svg in MiniTxCard.js

### DIFF
--- a/app/Modules/BlockExplorer/components/txs/MiniTxCard.js
+++ b/app/Modules/BlockExplorer/components/txs/MiniTxCard.js
@@ -5,7 +5,7 @@ import EtherUtil from 'ethereumjs-util'
 
 import FormattedHex from 'Elements/FormattedHex'
 
-import ContractIcon from 'babel!svg-react!../../../../../resources/Contract.svg?name=ContractIcon'
+import ContractIcon from 'babel!svg-react!../../../../../resources/contract.svg?name=ContractIcon'
 import Styles from './MiniTxCard.css'
 
 export default class MiniTxCard extends Component {


### PR DESCRIPTION
Running ganache from current develop produces an error:

```
ERROR in ./app/Modules/BlockExplorer/components/txs/MiniTxCard.js
Module not found: Error: Cannot resolve 'file' or 'directory' ../../../../../resources/Contract.svg in /home/theodor/github/montekki/ganache/app/Modules/BlockExplorer/components/txs
 @ ./app/Modules/BlockExplorer/components/txs/MiniTxCard.js 33:16-98
```

This commit fixes this broken path.