### PR TITLE
Replace heartbeat with start message & process exit event

### DIFF
--- a/src/Services/Chain.js
+++ b/src/Services/Chain.js
@@ -18,10 +18,10 @@ class ChainService extends EventEmitter {
       stdio: [ 'pipe', 'pipe', 'pipe', 'ipc' ]
     };
     this.child = fork(chainPath, [], options)
-    this.child.once('message', () => {
-      this.emit("start")
-    })
     this.child.on('message', (message) => {
+      if (message.type == "process-started") {
+        this.emit("start")
+      }
       if (message.type == "server-started") {
         this.serverStarted = true
       }

--- a/src/chain.js
+++ b/src/chain.js
@@ -137,23 +137,7 @@ process.on("message", function(message) {
   }
 });
 
-
-function sendHeartBeat() {
-  process.send({type: 'heartbeat'})
-}
-
-sendHeartBeat()
-
-// Keep an interval going so the process stays open.
-// We can use this interval to maintain a heartbeat
-setInterval(function() {
-  sendHeartBeat()
-}, 1000);
-
-process.on('uncaughtException', (err) => {
-  console.log(err.stack || err)
-  process.send({type: 'error', data: err.stack || err})
-});
+process.send({type: 'started'})
 
 // If you want to test out an error being thrown here
 // setTimeout(function() {

--- a/src/chain.js
+++ b/src/chain.js
@@ -137,6 +137,11 @@ process.on("message", function(message) {
   }
 });
 
+process.on('uncaughtException', (err) => {		
+  console.log(err.stack || err)		
+  process.send({type: 'error', data: err.stack || err})		
+});
+
 process.send({type: 'started'})
 
 // If you want to test out an error being thrown here

--- a/src/chain.js
+++ b/src/chain.js
@@ -142,7 +142,7 @@ process.on('uncaughtException', (err) => {
   process.send({type: 'error', data: err.stack || err})		
 });
 
-process.send({type: 'started'})
+process.send({type: 'process-started'})
 
 // If you want to test out an error being thrown here
 // setTimeout(function() {


### PR DESCRIPTION
Turns out the `child_process` module emits an event when the child process exits. Switched to using this for monitoring whether the process is alive. Relying on request timeouts for detection of when the process has hung.
