### PR TITLE
Include last log lines in bug report

### DIFF
--- a/src/Components/AppShell/AppShell.js
+++ b/src/Components/AppShell/AppShell.js
@@ -7,11 +7,7 @@ import connect from '../Helpers/connect'
 import * as AppShellActions from '../../Actions/AppShell'
 
 import TopNavbar from './TopNavbar'
-import OnlyIf from '../../Elements/OnlyIf'
-import Modal from '../../Elements/Modal'
-
-import BugIcon from '../../Elements/icons/errorant.svg'
-
+import BugModal from './BugModal'
 import ua from 'universal-analytics'
 import ElectronCookies from '@exponent/electron-cookies'
 
@@ -108,47 +104,8 @@ class AppShell extends Component {
 
   onCloseFatalErrorModal = () => {}
 
-  // grabs the last 500 log lines as a string formatted for inclusion as a github issue
-  prepareLogLines () {
-    if (this.props.logs.lines) {
-      let firstLogTime = this.props.logs.lines[0].time.getTime()
-      return this.props.logs.lines
-      .slice(-500) 
-      .map(v => `T+${v.time.getTime() - firstLogTime}ms: ${v.line}`)
-        .join('\n')
-    }
-
-    return ''
-  }
-
-  // Remove any user-specific paths in exception messages
-  sanitizePaths(message) {
-    // Prepare our paths so we *always* will get a match no matter
-    // path separator (oddly, on Windows, different errors will give
-    // us different path separators)
-    var appPath = app.getAppPath().replace(/\\/g, "/")
-
-    // I couldn't figure out the regex, so a loop will do.
-    while (message.indexOf(appPath) >= 0) {
-      message = systemError.replace(appPath, "")
-    }
-
-    return message;
-  }
-
   render () {
     const path = this.props.location.pathname
-    const segment = path.replace(/^\//g, '').replace(/\//g, '-') || 'root'
-    let systemError = this.props.core.systemError
-    let logLines = ''
-    if (systemError) {
-      systemError = systemError.stack || systemError
-
-      // avoid leaking details about the user's environment
-      systemError = this.sanitizePaths(systemError)
-      logLines = this.sanitizePaths(this.prepareLogLines())
-    }
-
     return (
       <div className="AppShell">
         <TopNavbar {...this.props} />
@@ -156,62 +113,10 @@ class AppShell extends Component {
         <div className="ShellContainer" ref="shellcontainer">
           {this.props.children}
         </div>
-
-        <OnlyIf test={systemError != null}>
-          <Modal> 
-            <section className="Bug">
-              <BugIcon /*size={192}*/ />
-              <h4>Uh Oh... That's a bug.</h4>
-              <p>
-                Ganache encountered an error. Help us fix it by raising a GitHub issue!<br/><br/> Mention the following error information when writing your ticket, and please include as much information as possible. Sorry about that!
-              </p>
-              <textarea disabled={true} value={systemError} />
-              <footer>
-                <button
-                  onClick={() => {
-                    const title = encodeURIComponent(
-                      `System Error when running Ganache ${app.getVersion()} on ${process.platform}`
-                    )
-
-                    const body = encodeURIComponent(
-                      `<!-- Please give us as much detail as you can about what you were doing at the time of the error, and any other relevant information -->
-
-PLATFORM: ${process.platform}
-GANACHE VERSION: ${app.getVersion()}
-
-EXCEPTION:
-\`\`\`
-${systemError}
-\`\`\`
-
-APPLICATION LOG:
-\`\`\`
-${logLines}
-\`\`\``
-                    ).replace(/%09/g, '')
-
-                    shell.openExternal(
-                      `https://github.com/trufflesuite/ganache/issues/new?title=${title}&body=${body}`
-                    )
-                  }}
-                >
-                  Raise Github Issue
-                </button>
-                <button
-                  onClick={() => {
-                    app.relaunch()
-                    app.exit()
-                  }}
-                >
-                  RELAUNCH
-                </button>
-              </footer>
-            </section>
-          </Modal>
-        </OnlyIf>
+        <BugModal core={this.props.core } logs={this.props.logs} />
       </div>
     )
   }
 }
 
-export default connect(AppShell, "core", "settings", "logs")
+export default connect(AppShell, "core", "settings", "logs");

--- a/src/Components/AppShell/AppShell.js
+++ b/src/Components/AppShell/AppShell.js
@@ -7,6 +7,7 @@ import connect from '../Helpers/connect'
 import * as AppShellActions from '../../Actions/AppShell'
 
 import TopNavbar from './TopNavbar'
+import OnlyIf from '../../Elements/OnlyIf'
 import BugModal from './BugModal'
 import ua from 'universal-analytics'
 import ElectronCookies from '@exponent/electron-cookies'
@@ -113,7 +114,9 @@ class AppShell extends Component {
         <div className="ShellContainer" ref="shellcontainer">
           {this.props.children}
         </div>
-        <BugModal core={this.props.core } logs={this.props.logs} />
+        <OnlyIf test={this.props.core.systemError != null}>
+          <BugModal core={this.props.core } logs={this.props.logs} />
+        </OnlyIf>
       </div>
     )
   }

--- a/src/Components/AppShell/AppShell.js
+++ b/src/Components/AppShell/AppShell.js
@@ -115,7 +115,7 @@ class AppShell extends Component {
           {this.props.children}
         </div>
         <OnlyIf test={this.props.core.systemError != null}>
-          <BugModal core={this.props.core } logs={this.props.logs} />
+          <BugModal systemError={this.props.core.systemError} logs={this.props.logs} />
         </OnlyIf>
       </div>
     )

--- a/src/Components/AppShell/AppShell.scss
+++ b/src/Components/AppShell/AppShell.scss
@@ -3,21 +3,6 @@
   flex-direction: column;
   height: 100%;
 
-  .Bug {
-    textarea {
-      min-height: 5rem; /* Overwrite Modal textarea styles */
-      max-height: 5rem;
-      background-color: var(--app-button-primary-disabled-border-color);
-      width: 100%;
-      margin-bottom: 1rem;
-    }
-
-    svg {
-      width: 192px;
-      height: 192px;
-    }
-  }
-
   .ShellContainer {
     display: flex;
     flex-grow: 1;

--- a/src/Components/AppShell/BugModal.js
+++ b/src/Components/AppShell/BugModal.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 
 import connect from '../Helpers/connect'
 
-import OnlyIf from '../../Elements/OnlyIf'
 import Modal from '../../Elements/Modal'
 
 import BugIcon from '../../Elements/icons/errorant.svg'
@@ -67,24 +66,23 @@ class BugModal extends Component {
     }
 
     return (
-      <OnlyIf test={systemError != null}>
-        <Modal className="BugModal">
-          <section className="Bug">
-            <BugIcon /*size={192}*/ />
-            <h4>Uh Oh... That's a bug.</h4>
-            <p>
-              Ganache encountered an error. Help us fix it by raising a GitHub issue!<br /><br /> Mention the following error information when writing your ticket, and please include as much information as possible. Sorry about that!
-              </p>
-            <textarea disabled={true} value={systemError} />
-            <footer>
-              <button
-                onClick={() => {
-                  const title = encodeURIComponent(
-                    `System Error when running Ganache ${app.getVersion()} on ${process.platform}`
-                  )
+      <Modal className="BugModal">
+        <section className="Bug">
+          <BugIcon /*size={192}*/ />
+          <h4>Uh Oh... That's a bug.</h4>
+          <p>
+            Ganache encountered an error. Help us fix it by raising a GitHub issue!<br /><br /> Mention the following error information when writing your ticket, and please include as much information as possible. Sorry about that!
+            </p>
+          <textarea disabled={true} value={systemError} />
+          <footer>
+            <button
+              onClick={() => {
+                const title = encodeURIComponent(
+                  `System Error when running Ganache ${app.getVersion()} on ${process.platform}`
+                )
 
-                  const body = encodeURIComponent(
-                    `<!-- Please give us as much detail as you can about what you were doing at the time of the error, and any other relevant information -->
+                const body = encodeURIComponent(
+                  `<!-- Please give us as much detail as you can about what you were doing at the time of the error, and any other relevant information -->
 
 PLATFORM: ${process.platform}
 GANACHE VERSION: ${app.getVersion()}
@@ -98,27 +96,26 @@ APPLICATION LOG:
 \`\`\`
 ${logLines}
 \`\`\``
-                  ).replace(/%09/g, '')
+                ).replace(/%09/g, '')
 
-                  shell.openExternal(
-                    `https://github.com/trufflesuite/ganache/issues/new?title=${title}&body=${body}`
-                  )
-                }}
-              >
-                Raise Github Issue
-                </button>
-              <button
-                onClick={() => {
-                  app.relaunch()
-                  app.exit()
-                }}
-              >
-                RELAUNCH
-                </button>
-            </footer>
-          </section>
-        </Modal>
-      </OnlyIf>
+                shell.openExternal(
+                  `https://github.com/trufflesuite/ganache/issues/new?title=${title}&body=${body}`
+                )
+              }}
+            >
+              Raise Github Issue
+              </button>
+            <button
+              onClick={() => {
+                app.relaunch()
+                app.exit()
+              }}
+            >
+              RELAUNCH
+              </button>
+          </footer>
+        </section>
+      </Modal>
     )
   }
 }

--- a/src/Components/AppShell/BugModal.js
+++ b/src/Components/AppShell/BugModal.js
@@ -1,0 +1,126 @@
+import React, { Component } from 'react'
+
+import connect from '../Helpers/connect'
+
+import OnlyIf from '../../Elements/OnlyIf'
+import Modal from '../../Elements/Modal'
+
+import BugIcon from '../../Elements/icons/errorant.svg'
+
+import { shell } from 'electron'
+
+const { app } = require('electron').remote
+
+class BugModal extends Component {
+  constructor () {
+    super()
+    this.scrollDedupeTimeout = null
+  }
+
+  _getLastNLines(maxLines) {
+    let firstLogTime = this.props.logs.lines[0].time.getTime()
+    return this.props.logs.lines
+      .slice(maxLines)
+      .map(v => `T+${v.time.getTime() - firstLogTime}ms: ${v.line}`)
+        .join('\n')
+  }
+  // grabs the last 500 log lines as a string formatted for inclusion as a github issue
+  prepareLogLines () {
+    let result = ''
+    if (this.props.logs.lines) {
+      let maxLines = -175
+
+      // GitHub has a max URL length of ~8KiB, so we truncate logs to fit within that
+      while (encodeURIComponent(result = this._getLastNLines(maxLines)).length > 7500) {
+        maxLines++
+      }
+
+    }
+
+    return result
+  }
+
+  // Remove any user-specific paths in exception messages
+  sanitizePaths(message) {
+    // Prepare our paths so we *always* will get a match no matter
+    // path separator (oddly, on Windows, different errors will give
+    // us different path separators)
+    var appPath = app.getAppPath().replace(/\\/g, "/")
+
+    // I couldn't figure out the regex, so a loop will do.
+    while (message.indexOf(appPath) >= 0) {
+      message = systemError.replace(appPath, "")
+    }
+
+    return message
+  }
+
+  render () {
+    let systemError = this.props.core.systemError
+    let logLines = ''
+    if (systemError) {
+      systemError = systemError.stack || systemError
+
+      // avoid leaking details about the user's environment
+      systemError = this.sanitizePaths(systemError)
+      logLines = this.sanitizePaths(this.prepareLogLines())
+    }
+
+    return (
+      <OnlyIf test={systemError != null}>
+        <Modal className="BugModal">
+          <section className="Bug">
+            <BugIcon /*size={192}*/ />
+            <h4>Uh Oh... That's a bug.</h4>
+            <p>
+              Ganache encountered an error. Help us fix it by raising a GitHub issue!<br /><br /> Mention the following error information when writing your ticket, and please include as much information as possible. Sorry about that!
+              </p>
+            <textarea disabled={true} value={systemError} />
+            <footer>
+              <button
+                onClick={() => {
+                  const title = encodeURIComponent(
+                    `System Error when running Ganache ${app.getVersion()} on ${process.platform}`
+                  )
+
+                  const body = encodeURIComponent(
+                    `<!-- Please give us as much detail as you can about what you were doing at the time of the error, and any other relevant information -->
+
+PLATFORM: ${process.platform}
+GANACHE VERSION: ${app.getVersion()}
+
+EXCEPTION:
+\`\`\`
+${systemError}
+\`\`\`
+
+APPLICATION LOG:
+\`\`\`
+${logLines}
+\`\`\``
+                  ).replace(/%09/g, '')
+
+                  shell.openExternal(
+                    `https://github.com/trufflesuite/ganache/issues/new?title=${title}&body=${body}`
+                  )
+                }}
+              >
+                Raise Github Issue
+                </button>
+              <button
+                onClick={() => {
+                  app.relaunch()
+                  app.exit()
+                }}
+              >
+                RELAUNCH
+                </button>
+            </footer>
+          </section>
+        </Modal>
+      </OnlyIf>
+    )
+  }
+}
+
+export default connect(BugModal)

--- a/src/Components/AppShell/BugModal.scss
+++ b/src/Components/AppShell/BugModal.scss
@@ -1,16 +1,18 @@
-.BugModal {
-  .Bug {
-    textarea {
-      min-height: 5rem; /* Overwrite Modal textarea styles */
-      max-height: 5rem;
-      background-color: var(--app-button-primary-disabled-border-color);
-      width: 100%;
-      margin-bottom: 1rem;
-    }
+.Modal {
+  &.BugModal {
+    .Bug {
+      textarea {
+        min-height: 5rem; /* Overwrite Modal textarea styles */
+        max-height: 5rem;
+        background-color: var(--app-button-primary-disabled-border-color);
+        width: 100%;
+        margin-bottom: 1rem;
+      }
 
-    svg {
-      width: 192px;
-      height: 192px;
+      svg {
+        width: 192px;
+        height: 192px;
+      }
     }
   }
 }

--- a/src/Components/AppShell/BugModal.scss
+++ b/src/Components/AppShell/BugModal.scss
@@ -1,0 +1,16 @@
+.BugModal {
+  .Bug {
+    textarea {
+      min-height: 5rem; /* Overwrite Modal textarea styles */
+      max-height: 5rem;
+      background-color: var(--app-button-primary-disabled-border-color);
+      width: 100%;
+      margin-bottom: 1rem;
+    }
+
+    svg {
+      width: 192px;
+      height: 192px;
+    }
+  }
+}

--- a/src/Components/Helpers/sanitize.js
+++ b/src/Components/Helpers/sanitize.js
@@ -1,0 +1,23 @@
+
+const { app } = require('electron').remote
+
+// return a sanitized error string from an Error object or string which contains an error message
+export function sanitizeError(errorUnsanitized) {
+  return sanitizePaths(errorUnsanitized.stack || errorUnsanitized)
+}
+
+// Remove any user-specific paths in exception messages
+export function sanitizePaths (message) {
+  // Prepare our paths so we *always* will get a match no matter
+  // path separator (oddly, on Windows, different errors will give
+  // us different path separators)
+  var appPath = app.getAppPath().replace(/\\/g, "/")
+
+  // I couldn't figure out the regex, so a loop will do.
+  while (message.indexOf(appPath) >= 0) {
+    message = message.replace(appPath, "")
+  }
+
+  return message
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ const stylesheets = [
   "./Components/FirstRun/FirstRunScreen.scss",
   "./Components/AppShell/AppShell.scss",
   "./Components/AppShell/TopNavbar.scss",
+  "./Components/AppShell/BugModal.scss",
   "./Components/Accounts/AccountsScreen.scss",
   "./Components/Accounts/AccountList.scss",
   "./Components/Accounts/KeyModal.scss",


### PR DESCRIPTION
In order to give us more context when debugging user-submitted issues from the application, include up to the ~last 500 log lines~ in the bug report. [Edit: actually, 500 was too much, I made it so that it includes the last N log lines such that url encoding those lines doesn't exceed 7500 chars.] **This generates a GitHub issue which looks like the following example**:

<!-- Please give us as much detail as you can about what you were doing at the time of the error, and any other relevant information -->

PLATFORM: darwin
GANACHE VERSION: 1.6.11

EXCEPTION:
```
Blockchain process exited prematurely due to signal 'SIGTERM'.
```

APPLICATION LOG:
```
T+0ms: Starting server with configuration: {"hostname":"localhost","network_id":5777,"port":7545,"total_accounts":10,"unlocked_accounts":[]}
T+483ms: Ganache started successfully!
T+483ms: Waiting for requests...
```
