### PR TITLE
Add version number

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -3,7 +3,7 @@ var ganacheLib = require("ganache-cli")
 var path = require("path")
 var Web3 = require("web3")
 
-import * as pkg from '../../../package.json'
+import * as pkg from '../package.json'
 
 if (!process.send) {
   throw new Error("Must be run as a child process!")

--- a/src/chain.js
+++ b/src/chain.js
@@ -29,7 +29,7 @@ function stopServer(callback) {
 
 function startServer(options) {
   stopServer(function() {
-    console.log("Starting server version "+pkg.version+" with configuration: " + JSON.stringify(options))
+    console.log("Starting server version " + pkg.version + " with configuration: " + JSON.stringify(options))
 
     // The TestRPC's logging system is archaic. We'd like more control
     // over what's logged. For now, the really important stuff all has

--- a/src/chain.js
+++ b/src/chain.js
@@ -3,6 +3,8 @@ var ganacheLib = require("ganache-cli")
 var path = require("path")
 var Web3 = require("web3")
 
+import * as pkg from '../../../package.json'
+
 if (!process.send) {
   throw new Error("Must be run as a child process!")
 }
@@ -27,7 +29,7 @@ function stopServer(callback) {
 
 function startServer(options) {
   stopServer(function() {
-    console.log("Starting server with configuration: " + JSON.stringify(options))
+    console.log("Starting server version "+pkg.version+" with configuration: " + JSON.stringify(options))
 
     // The TestRPC's logging system is archaic. We'd like more control
     // over what's logged. For now, the really important stuff all has


### PR DESCRIPTION
Adds version number in a place where people can easily find it while or after Ganache is running.  See also https://github.com/trufflesuite/ganache/commit/d4b1cbd8776153a53d3e58d4339baedbad94415d

Ganache could benefit from a user-friendly way to know what version is running, from the GUI, and to be able to reconstruct that information when analyzing logs historically.  That the default download filename has no version number and the source link (AWS) strips that information out of the URL doesn't help.  (It is displayed briefly on startup in a splash screen).  

An easy way to do this is adding the version number to the startup line at the top of the logs, which is the intention of this contribution. 
