### PR TITLE
Add optional dependencies to package-lock.json.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,27 @@
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.3.4.tgz",
       "integrity": "sha512-s2ZfgRWXeNUQTQE3O85CDDrU2Uo90pMlMkTxkz85wQOuzVxB8t4cubMPup3WlTPFKHQgb6lDkAHS3ljkUSFO6A==",
       "requires": {
-        "7zip-bin-mac": "1.0.1"
+        "7zip-bin-linux": "1.3.1",
+        "7zip-bin-mac": "1.0.1",
+        "7zip-bin-win": "2.2.0"
       }
+    },
+    "7zip-bin-linux": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
+      "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
+      "optional": true
     },
     "7zip-bin-mac": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
       "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
+      "optional": true
+    },
+    "7zip-bin-win": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.2.0.tgz",
+      "integrity": "sha512-uPHXapEmUtlUKTBx4asWMlxtFUWXzEY0KVEgU7QKhgO2LJzzM3kYxM6yOyUZTtYE6mhK4dDn3FDut9SCQWHzgg==",
       "optional": true
     },
     "@exponent/electron-cookies": {


### PR DESCRIPTION
Add OS-specific optional dependecies of 7zip-bin to package-lock.json.
These entries were created using "npm install --package-lock-only".
This fixes #399.
