### PR TITLE
Update Web3.js

### DIFF
--- a/src/Actions/Web3.js
+++ b/src/Actions/Web3.js
@@ -10,6 +10,7 @@ export function setWeb3Instance(web3Instance) {
 
 export const SET_RPC_PROVIDER_URL = `${prefix}/SET_RPC_PROVIDER_URL`
 export function setRPCProviderUrl(url) {
+  url = url.replace('0.0.0.0', '127.0.0.1')
   return function(dispatch, getState) {
     const provider = new ReduxWeb3Provider(url, dispatch, getState)
     const web3Instance = new Web3(provider)


### PR DESCRIPTION
So the provider will connect to 127.0.0.1 when the server is started to listen on 0.0.0.0. This enables the server to listen on all network addresses by specifying host as 0.0.0.0, without breaking the UI functionality. 

Currently when the host is set to 0.0.0.0, the server is started successfully to listen on all network addresses, but the client UI will be blank as it cannot connect to 0.0.0.0.

## Ganache

Thank you for contributing! Take a moment to review our [**contributing guidelines**](https://github.com/trufflesuite/ganache/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**You must open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/trufflesuite/ganache/blob/master/.github/CONTRIBUTING.md)
- [ ] Pull request has tests
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch via a Pull Request, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/trufflesuite/ganache/blob/master/LICENSE.md).
