### PR TITLE
Make mac "Window" menu work for Accounts, Blocks...

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ import NotFoundScreen from './Components/NotFound/NotFoundScreen'
 import TitleScreen from './Components/Title/TitleScreen'
 import FirstRunScreen from './Components/FirstRun/FirstRunScreen'
 
+import {ipcRenderer} from 'electron'
+
 const store = createStore(RootReducer)
 
 ready(store)
@@ -41,6 +43,10 @@ const routes = <Route>
     <Route path='/config' component={ConfigScreen} /> 
   </Route>
 </Route>
+
+ipcRenderer.on('navigate', (event, path) => {
+    hashHistory.push(path)
+});
 
 const stylesheets = [
   "./Styles/colors.scss",

--- a/src/main.js
+++ b/src/main.js
@@ -179,6 +179,7 @@ app.on('ready', () => {
     })
 
     if (process.platform === 'darwin') {
+      const navigate = (path) => mainWindow.webContents.send('navigate', path);
       template = [
         {
           label: 'Ganache',
@@ -186,6 +187,17 @@ app.on('ready', () => {
             {
               label: 'About Ganache ' + app.getVersion(),
               selector: 'orderFrontStandardAboutPanel:'
+            },
+            {
+              type: 'separator'
+            },
+            {
+              label: 'Preferences...',
+              accelerator: 'Command+,',
+              click(){ navigate('/config') }
+            },
+            {
+                type: 'separator'
             },
             {
               type: 'separator'
@@ -304,27 +316,27 @@ app.on('ready', () => {
             {
               label: 'Accounts',
               accelerator: 'Command+1',
-              selector: 'performAccounts:'
+              click(){ navigate('/accounts') }
             },
             {
               label: 'Blocks',
               accelerator: 'Command+2',
-              selector: 'performBlocks:'
+              click(){ navigate('/blocks') }
             },
             {
               label: 'Transactions',
               accelerator: 'Command+3',
-              selector: 'performTransactions:'
+              click(){ navigate('/transactions') }
             },
             {
-              label: 'Console',
+              label: 'Logs',
               accelerator: 'Command+4',
-              selector: 'performConsole:'
+              click(){ navigate('/logs') }
             },
             {
               label: 'Settings',
               accelerator: 'Command+5',
-              selector: 'performSettings:'
+              click(){ navigate('/config') }
             },
             {
               label: 'Minimize',


### PR DESCRIPTION
## Window menu on macos

<img width="708" alt="screen shot 2018-04-16 at 9 04 35 pm" src="https://user-images.githubusercontent.com/2255137/38810635-f5dc6b3c-41b9-11e8-8e6a-a3fdaddefa10.png">

It is currently using `selector` and does nothing when we click on the following menu items

1.  Accounts
2. Blocks
3. Transitions
4. Console (renamed to *Logs* for consistency and a better name)
5. Settings

This pull request fixes them

-------------------------

## Preferences menu item

Did not exist before, it is now added and navigates to the settings screen

<img width="315" alt="screen shot 2018-04-16 at 9 10 53 pm" src="https://user-images.githubusercontent.com/2255137/38810902-b1942766-41ba-11e8-91e8-70cd7731b3a5.png">
