### PR TITLE
Add Scrollbars to Main Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,6 +195,11 @@
         "acorn": "2.7.0"
       }
     },
+    "add-px-to-style": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-px-to-style/-/add-px-to-style-1.0.0.tgz",
+      "integrity": "sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo="
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -4678,6 +4683,16 @@
         "iconv-lite": "0.4.19",
         "js-yaml": "3.11.0",
         "parse-color": "1.0.0"
+      }
+    },
+    "dom-css": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-css/-/dom-css-2.1.0.tgz",
+      "integrity": "sha1-/bwtWgFdCj4YcuEUcrvQ57nmogI=",
+      "requires": {
+        "add-px-to-style": "1.0.0",
+        "prefix-style": "2.0.1",
+        "to-camel-case": "1.0.0"
       }
     },
     "dom-serializer": {
@@ -14448,6 +14463,11 @@
         "which-pm-runs": "1.0.0"
       }
     },
+    "prefix-style": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prefix-style/-/prefix-style-2.0.1.tgz",
+      "integrity": "sha1-ZrupqHDP2jCKXcIOhekSCTLJWgY="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -14642,6 +14662,14 @@
         "prebuild-install": "2.5.1"
       }
     },
+    "raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "requires": {
+        "performance-now": "2.1.0"
+      }
+    },
     "random-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz",
@@ -14784,6 +14812,16 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/react-attr-converter/-/react-attr-converter-0.3.1.tgz",
       "integrity": "sha512-dSxo2Mn6Zx4HajeCeQNLefwEO4kNtV/0E682R1+ZTyFRPqxDa5zYb5qM/ocqw9Bxr/kFQO0IUiqdV7wdHw+Cdg=="
+    },
+    "react-custom-scrollbars": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz",
+      "integrity": "sha1-gw/ZUCkn6X6KeMIIaBOJmyqLZts=",
+      "requires": {
+        "dom-css": "2.1.0",
+        "prop-types": "15.6.1",
+        "raf": "3.4.0"
+      }
     },
     "react-deep-force-update": {
       "version": "2.1.1",
@@ -17419,10 +17457,23 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-camel-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+      "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
+      "requires": {
+        "to-space-case": "1.0.0"
+      }
+    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -17464,6 +17515,14 @@
             "kind-of": "3.2.2"
           }
         }
+      }
+    },
+    "to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "requires": {
+        "to-no-case": "1.0.2"
       }
     },
     "touch": {

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "pluralize": "^5.0.0",
     "rabin-bindings": "^1.7.4",
     "react": "^15.4.2",
+    "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^15.6.2",
     "react-hot-loader": "^3.1.1",
     "react-marked-markdown": "^1.4.6",

--- a/src/Components/AppShell/AppShell.js
+++ b/src/Components/AppShell/AppShell.js
@@ -115,10 +115,7 @@ class AppShell extends Component {
 
         <div className="ShellContainer" ref="shellcontainer">
           <Scrollbars
-            className="scrollBar"
-            autoHide
-            autoHideTimeout={1000}
-            autoHideDuration={200}>
+            className="scrollBar">
             {this.props.children}
           </Scrollbars>
         </div>

--- a/src/Components/AppShell/AppShell.js
+++ b/src/Components/AppShell/AppShell.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import Mousetrap from 'mousetrap'
 import { hashHistory } from 'react-router'
 import { shell } from 'electron'
+import { Scrollbars } from 'react-custom-scrollbars';
 
 import connect from '../Helpers/connect'
 import * as AppShellActions from '../../Actions/AppShell'
@@ -113,7 +114,13 @@ class AppShell extends Component {
         <TopNavbar {...this.props} />
 
         <div className="ShellContainer" ref="shellcontainer">
-          {this.props.children}
+          <Scrollbars
+            className="scrollBar"
+            autoHide
+            autoHideTimeout={1000}
+            autoHideDuration={200}>
+            {this.props.children}
+          </Scrollbars>
         </div>
         <OnlyIf test={this.props.core.systemError != null}>
           <BugModal systemError={this.props.core.systemError} logs={this.props.logs} />

--- a/src/Components/AppShell/AppShell.scss
+++ b/src/Components/AppShell/AppShell.scss
@@ -7,7 +7,7 @@
     display: flex;
     flex-grow: 1;
     justify-content: center;
-    overflow: hidden;
+    overflow: hidden; // Scrolling is handled using react-custom-scrollbars
     height: 100%;
   }
 

--- a/src/Components/AppShell/AppShell.scss
+++ b/src/Components/AppShell/AppShell.scss
@@ -7,7 +7,7 @@
     display: flex;
     flex-grow: 1;
     justify-content: center;
-    overflow: scroll;
+    overflow: hidden;
     height: 100%;
   }
 

--- a/src/Components/Logs/LogContainer.js
+++ b/src/Components/Logs/LogContainer.js
@@ -29,9 +29,6 @@ class LogContainer extends Component {
         <ul ref="LogItems">
           <Scrollbars
             className="scrollBar"
-            autoHide
-            autoHideTimeout={1000}
-            autoHideDuration={200}
             renderThumbVertical={props => <div {...props} className="scroll-light"/>}>
             {this.props.logs.lines.map((log, index) => {
               return (

--- a/src/Components/Logs/LogContainer.js
+++ b/src/Components/Logs/LogContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Scrollbars } from 'react-custom-scrollbars';
 import connect from '../Helpers/connect'
 
 class LogContainer extends Component {
@@ -26,13 +27,20 @@ class LogContainer extends Component {
     return (
       <div className="LogContainer" ref="LogContainer">
         <ul ref="LogItems">
-          {this.props.logs.lines.map((log, index) => {
-            return (
-              <li key={index} className="plain">
-                {`[${new Date(log.time).toLocaleTimeString()}]`} {log.line}
-              </li>
-            )
-          })}
+          <Scrollbars
+            className="scrollBar"
+            autoHide
+            autoHideTimeout={1000}
+            autoHideDuration={200}
+            renderThumbVertical={props => <div {...props} className="scroll-light"/>}>
+            {this.props.logs.lines.map((log, index) => {
+              return (
+                <li key={index} className="plain">
+                  {`[${new Date(log.time).toLocaleTimeString()}]`} {log.line}
+                </li>
+              )
+            })}
+          </Scrollbars>
         </ul>
       </div>
     )

--- a/src/Components/Logs/LogContainer.scss
+++ b/src/Components/Logs/LogContainer.scss
@@ -17,7 +17,6 @@
     margin: 0;
     padding: 1rem;
     font-family: "Fira Code Regular", monospace;
-    overflow: scroll;
     position: absolute;
     top: 0em;
     left: 0em;

--- a/src/app.global.scss
+++ b/src/app.global.scss
@@ -60,10 +60,6 @@
   src: url("../resources/fonts/GrandHotel-Regular.ttf") format("truetype");
 }
 
-::-webkit-scrollbar {
-    display: none;
-}
-
 *,
 *:before,
 *:after {
@@ -124,3 +120,6 @@ textarea {
 	-webkit-app-region: no-drag;
 }
 
+.scroll-light {
+  background-color: rgba(255, 255, 255, 0.2);
+}


### PR DESCRIPTION
This PR adds the `react-custom-scrollbars` npm module to have better-looking scrollbars. The scrollbars have been added to the main page, wrapping everything in `ShellContainer`, as well as wrapping the `<li>` elements in `LogContainer`.

More documentation on this module can be found at https://github.com/malte-wessel/react-custom-scrollbars/tree/master/docs

Has been tested on Linux; see the below GIF.
![peek 2018-05-18 10-03](https://user-images.githubusercontent.com/549323/40319875-ba83002e-5cf7-11e8-95f8-8bbdd679fef5.gif)
