### PR TITLE
Change websocket url to https instead of git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16207,7 +16207,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.27",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+        "websocket": "https://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
       },
       "dependencies": {
         "underscore": {
@@ -16508,8 +16508,8 @@
       }
     },
     "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-      "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+      "version": "https://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+      "from": "https://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
       "requires": {
         "debug": "^2.2.0",
         "nan": "^2.3.3",


### PR DESCRIPTION
Inspired by #857, this PR removes the `git://` URLs in `package-lock.json`. It doesn't appear to matter either way as `npm install` does work with the `git://` protocol.