### PR TITLE
Implement Error Modals

### DIFF
--- a/src/renderer/components/modal/ErrorModal.js
+++ b/src/renderer/components/modal/ErrorModal.js
@@ -23,12 +23,12 @@ class ErrorModal extends PureComponent {
     let icon
     switch (data.type){
       case ModalDetails.types.WARNING:
-        subTitle = "ICON - WARNING"
+        subTitle = "WARNING"
         icon = <WarningIcon />;
       break
       case ModalDetails.types.ERROR:
         console.error(this.props.modalError)
-        subTitle = "ICON - ERROR"
+        subTitle = "ERROR"
         icon = <ErrorIcon />;
       break
     }

--- a/src/renderer/screens/contracts/ContractCard.js
+++ b/src/renderer/screens/contracts/ContractCard.js
@@ -1,53 +1,72 @@
 import React, { Component } from 'react'
 
-import { Link } from 'react-router'
+import { push } from 'react-router-redux'
 
-import OnlyIf from '../../components/only-if/OnlyIf'
+import connect from '../helpers/connect'
+import ModalDetails from "../../components/modal/ModalDetails"
 
-export default class ContractCard extends Component {
+class ContractCard extends Component {
+  handleClick() {
+    if (this.props.address) {
+      push(`/contracts/${this.props.projectIndex}/${this.props.address}`);
+    }
+    else {
+      const modalDetails = new ModalDetails(
+        ModalDetails.types.WARNING,
+        [{
+          value: "OK"
+        }],
+        "Contract Not Deployed",
+        "This contract is not deployed yet. Please deploy this contract to see more info"
+      )
+
+      this.props.dispatch(ModalDetails.actions.setModalError(modalDetails))
+    }
+  }
+
   render () {
     return (
-      <Link
-        to={`/contracts/${this.props.projectIndex}/${this.props.address || "undeployed"}`}
-        className="Link"
+      <div
+        className="ContractCard"
+        onClick={this.handleClick.bind(this)}
       >
-        <div className="ContractCard">
-          <div className="Row">
-            <div className="RowItem">
-              <div className="Name">
-                <div className="Label">NAME</div>
-                <div className="Value">
-                  {this.props.name}
-                </div>
-              </div>
-            </div>
-
-            <div className="RowItem">
-              <div className="Address">
-                <div className="Label">ADDRESS</div>
-                <div className="Value">
-                  {this.props.address || "Not Deployed"}
-                </div>
-              </div>
-            </div>
-
-            <div className="RowItem">
-              <div className="TxCount">
-                <div className="Label">TX COUNT</div>
-                <div className="Value">
-                  {this.props.txCount}
-                </div>
-              </div>
-            </div>
-
-            <div className="RowItem StatusBadge">
-              <div className="Badge">
-                <div className="Label">{this.props.address !== "" && "DEPLOYED"}</div>
+        <div className="Row">
+          <div className="RowItem">
+            <div className="Name">
+              <div className="Label">NAME</div>
+              <div className="Value">
+                {this.props.name}
               </div>
             </div>
           </div>
+
+          <div className="RowItem">
+            <div className="Address">
+              <div className="Label">ADDRESS</div>
+              <div className="Value">
+                {this.props.address || "Not Deployed"}
+              </div>
+            </div>
+          </div>
+
+          <div className="RowItem">
+            <div className="TxCount">
+              <div className="Label">TX COUNT</div>
+              <div className="Value">
+                {this.props.txCount}
+              </div>
+            </div>
+          </div>
+
+          <div className="RowItem StatusBadge">
+            <div className="Badge">
+              <div className="Label">{this.props.address !== "" && "DEPLOYED"}</div>
+            </div>
+          </div>
         </div>
-      </Link>
+      </div>
     )
   }
 }
+
+export default connect(ContractCard)


### PR DESCRIPTION
This PR implements using the error modals (see #921) as designed from the mockups. It just adds:
- A modal for removing a project in the config screen when the project has 1 or more **deployed** contracts
- A modal for trying to load the contract details of an undeployed contract