### PR TITLE
Format event cards

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -105,6 +105,7 @@ const stylesheets = [
   "./screens/contracts/ContractDetailsScreen.scss",
   "./screens/events/EventList.scss",
   "./screens/events/EventsScreen.scss",
+  "./screens/events/EventItem.scss",
   "./screens/event-details/EventDetailsScreen.scss",
   "./screens/event-details/EncodedEventDetails.scss",
   "./screens/event-details/DecodedEventDetails.scss",

--- a/src/renderer/screens/events/EventItem.js
+++ b/src/renderer/screens/events/EventItem.js
@@ -12,32 +12,60 @@ class EventItem extends Component {
       this.props.dispatch(push(`/event_details/${transactionHash}/${logIndex}`))
     return (
       <div className="EventItem" onClick={goToEventDetails}>
-        <div className="name">
-          <div className="label">NAME</div>
-          <div className="value">{name || "ENCODED EVENT"}</div>
-        </div>
-        <div className="data">
-          <div className="dataItem">
-            <div className="label">CONTRACT</div>
-            <div className="value">{contract}</div>
-          </div>
-          <div className="dataItem">
-            <div className="label">TX HASH</div>
-            <div className="value">{transactionHash}</div>
-          </div>
-          <div className="dataItem">
-            <div className="label">LOG INDEX</div>
-            <div className="value">{logIndex}</div>
-          </div>
-          <div className="dataItem">
-            <div className="label">BLOCK TIME</div>
-            <div className="value">
-              <Moment unix format="YYYY-MM-DD HH:mm:ss">
-                {timestamp}
-              </Moment>
+        <div className="Row Top">
+          <div className="RowItem">
+            <div className="Name">
+              <div className="Label">EVENT NAME</div>
+              <div className="Value">
+                {name || "Encoded Event"}
+              </div>
             </div>
           </div>
         </div>
+
+        <div className="SecondaryItems">
+          <div className="Row">
+            <div className="RowItem">
+              <div className="Contract">
+                <div className="Label">CONTRACT</div>
+                <div className="Value">
+                  {contract || "Unknown (no recognized contract)"}
+                </div>
+              </div>
+            </div>
+
+            <div className="RowItem">
+              <div className="TransactionHash">
+                <div className="Label">TX HASH</div>
+                <div className="Value">
+                  {transactionHash}
+                </div>
+              </div>
+            </div>
+
+            <div className="RowItem">
+              <div className="LogIndex">
+                <div className="Label">LOG INDEX</div>
+                <div className="Value">
+                  {logIndex}
+                </div>
+              </div>
+            </div>
+
+            <div className="RowItem">
+              <div className="BlockTime">
+                <div className="Label">BLOCK TIME</div>
+                <div className="Value">
+                  <Moment unix format="YYYY-MM-DD HH:mm:ss">
+                    {timestamp}
+                  </Moment>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
       </div>
     )
   }

--- a/src/renderer/screens/events/EventItem.js
+++ b/src/renderer/screens/events/EventItem.js
@@ -7,7 +7,7 @@ import connect from "../helpers/connect"
 
 class EventItem extends Component {
   render() {
-    const { name, contract, transactionHash, timestamp, logIndex } = this.props.event
+    const { name, contract, address, transactionHash, timestamp, logIndex } = this.props.event
     const goToEventDetails = () =>
       this.props.dispatch(push(`/event_details/${transactionHash}/${logIndex}`))
     return (
@@ -29,7 +29,7 @@ class EventItem extends Component {
               <div className="Contract">
                 <div className="Label">CONTRACT</div>
                 <div className="Value">
-                  {contract || "Unknown (no recognized contract)"}
+                  {contract || address}
                 </div>
               </div>
             </div>

--- a/src/renderer/screens/events/EventItem.scss
+++ b/src/renderer/screens/events/EventItem.scss
@@ -1,0 +1,71 @@
+.EventItem {
+    font-family: "Fira Code Regular", monospaced;
+    width: 100%;
+    cursor: pointer;
+    margin: .5rem 0;
+    background: var(--app-card-default-background);
+    padding: 28px 18px;
+    word-wrap: break-word;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    transition: all .3s;
+    border-bottom: 1px solid #aaa;
+  
+    .Row {
+      // display: flex;
+      // align-items: center;
+      // flex-direction: row;
+      margin-bottom: 1rem;
+      // justify-content: space-between;
+      display: grid;
+      grid-template-columns: 1fr 1fr 120px 200px;
+  
+      &.Top {
+        display: flex;
+        justify-content: space-between;
+      }
+  
+      &:last-of-type {
+        margin-bottom: 0;
+      }
+    }
+  
+    .RowItem {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      cursor: pointer;
+      margin-right: 2rem;
+    }
+  
+    .Label {
+      font-size: .75rem;
+      font-family: "RobotoCondensed-Regular";
+      font-weight: 800;
+      color: var(--app-card-label);
+      margin-bottom: .25rem;
+    }
+  
+    .Value {
+      font-size: 1.125rem;
+      font-family: "Fira Code Regular";
+      color: var(--app-card-value);
+      word-break: break-all;
+    }
+  
+    .Name {
+      .Value {
+        font-weight: bold;
+      }
+    }
+  
+    .SecondaryItems {
+      .Value {
+        font-size: .825rem;
+      }
+    }
+  
+  }
+  


### PR DESCRIPTION
Related to #986. This pulls the same SCSS and dom structure from transaction cards (MiniTxCards) and copies that over to the event cards (EventItem).

Note that this is a bit of copy-pasta wrt CSS. 

There's likely more things we can do to dress up the event cards. This is probably good enough to close #986 and we dress it up more later.

![image](https://user-images.githubusercontent.com/92629/49206501-20118400-f367-11e8-9f90-069d683cf4b1.png)

Compare to the transaction card:

![image](https://user-images.githubusercontent.com/92629/49206533-3ae3f880-f367-11e8-9653-77ef0ca302ba.png)
