### PR TITLE
Handle errors with loading a truffle project

### DIFF
--- a/src/common/redux/workspaces/reducers.js
+++ b/src/common/redux/workspaces/reducers.js
@@ -51,7 +51,9 @@ export default function (state = initialState, action) {
 
       for (let i = 0; i < nextState.current.projects.length; i++) {
         const project = nextState.current.projects[i]
-        linkContractCacheToProject(nextState.current.contractCache, project)
+        if (typeof project.error === "undefined") {
+          linkContractCacheToProject(nextState.current.contractCache, project)
+        }
       }
       break
     case CONTRACT_TRANSACTION: {

--- a/src/common/services/TruffleIntegrationService.js
+++ b/src/common/services/TruffleIntegrationService.js
@@ -79,12 +79,7 @@ class TruffleIntegrationService extends EventEmitter {
   async getProjectDetails(projectConfigFile, networkId) {
     return new Promise((resolve, reject) => {
       this.once("project-details-response", (details) => {
-        if (typeof details === "object") {
-          resolve(details);
-        }
-        else {
-          reject(details);
-        }
+        resolve(details);
       })
 
       if (this.child !== null && this.child.connected) {

--- a/src/renderer/screens/contracts/ContractsScreen.js
+++ b/src/renderer/screens/contracts/ContractsScreen.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
+import path from "path"
 import connect from '../helpers/connect'
 import ProjectContracts from './ProjectContracts';
+import OnlyIf from "../../components/only-if/OnlyIf";
 
 class ContractsScreen extends Component {
 
@@ -8,6 +10,29 @@ class ContractsScreen extends Component {
     let content
     if (this.props.workspaces.current.projects.length > 0) {
       content = this.props.workspaces.current.projects.map((project, index) => {
+        let errorMessage
+        if (typeof project.error !== "undefined") {
+          switch (project.error) {
+            case "project-does-not-exist": {
+              errorMessage = (
+                <span><strong>Your Truffle Project can no longer be found.</strong> Did you delete or move it? Update the location in the settings screen or restart Ganache.</span>
+              )
+              break;
+            }
+            case "invalid-project-file": {
+              errorMessage = (
+                <span><strong>Your Truffle Project config is invalid.</strong> The file should either be 'truffle.js' or 'truffle-config.js'. Update the file in the settings screen.</span>
+              )
+              break;
+            }
+            default: {
+              errorMessage = (
+                <span><strong>Unknown error:</strong> {project.error}</span>
+              )
+              break;
+            }
+          }
+        }
         return (
           <div
             className="Project"
@@ -15,13 +40,21 @@ class ContractsScreen extends Component {
           >
             <div className="ProjectName">
               <h2>{project.name}</h2>
-              <span>{project.config.truffle_directory}</span>
+              <span>{project.config ? project.config.truffle_directory : path.dirname(project.configFile)}</span>
             </div>
-            <ProjectContracts
-              contracts={project.contracts}
-              contractCache={this.props.workspaces.current.contractCache}
-              projectIndex={index}
-            />
+            <OnlyIf test={typeof project.error === "undefined"}>
+              <ProjectContracts
+                contracts={project.contracts}
+                contractCache={this.props.workspaces.current.contractCache}
+                projectIndex={index}
+              />
+            </OnlyIf>
+            <OnlyIf test={typeof project.error !== "undefined"}>
+              <div className="Notice">
+                <span className="Warning">⚠</span>{" "}
+                {errorMessage}
+              </div>
+            </OnlyIf>
           </div>
         )
       })

--- a/src/renderer/screens/contracts/ContractsScreen.scss
+++ b/src/renderer/screens/contracts/ContractsScreen.scss
@@ -10,6 +10,19 @@
       color: var(--app-card-value);
     }
   }
+
+  .Notice {
+    background: #ddd;
+    padding: 1rem;
+    border-radius: 6px;
+    margin: 1rem;
+    text-align: center;
+  }
+
+  .Warning {
+    font-size: 24px;
+    vertical-align: middle;
+  }
 }
 
 .ProjectContracts {

--- a/src/truffle-integration/index.js
+++ b/src/truffle-integration/index.js
@@ -56,7 +56,7 @@ process.on("message", async function(message) {
     case "project-details-request": {
       let response = getProjectDetails(message.data.file);
 
-      if (typeof response === "object") {
+      if (typeof response.error === "undefined") {
         response = watcher.add(response, message.data.networkId);
       }
 

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -3,15 +3,23 @@ const path = require("path");
 const TruffleConfig = require("truffle-config");
 
 function get(projectFile) {
+  const configFileDirectory = path.dirname(projectFile);
+  const name = path.basename(configFileDirectory);
   if (!fs.existsSync(projectFile)) {
-    return "Truffle project config file '" + projectFile + "' does not exist";
+    return {
+      name,
+      configFile: projectFile,
+      error: "project-does-not-exist"
+    };
   }
   else if (path.basename(projectFile).match(/^truffle(-config)?.js$/) === null) {
-    return "Truffle project config file '" + projectFile + "' is not a valid config file (must point to a file with the name 'truffle.js' or 'truffle-config.js'";
+    return {
+      name,
+      configFile: projectFile,
+      error: "invalid-project-file"
+    };
   }
   else {
-    const configFileDirectory = path.dirname(projectFile);
-    const name = path.basename(configFileDirectory);
     let config = new TruffleConfig(configFileDirectory, configFileDirectory, "ganache");
     const output = require(projectFile);
     config.merge(output);


### PR DESCRIPTION
This PR adds some better error handling when loading truffle projects.

It adds handling for the two different errors:
- Fixes #1018 by handling a moved/deleted truffle project config file
- Handles if somehow the project file is not a `truffle.js` or `truffle-config.js` file

The error is shown on the contract page. Here is a screenshot of the first case:
![image](https://user-images.githubusercontent.com/549323/49690102-571b2e80-faf9-11e8-8acd-9fef87f4d6ad.png)

and the second case:
![image](https://user-images.githubusercontent.com/549323/49690108-6bf7c200-faf9-11e8-95c2-c5bb6b0c8b28.png)



I'm going to merge this on my own, but CCing @DiscRiskandBisque and @honestbonsai for posterity's sake.