### PR TITLE
`require()` Truffle Project Configs in a Separate Process which Has No Native Dependencies

### DIFF
--- a/src/truffle-integration/index.js
+++ b/src/truffle-integration/index.js
@@ -4,42 +4,39 @@ const DecodeHelpers = require("./decode");
 
 let web3Host;
 
-watcher = new ProjectsWatcher();
+const watcher = new ProjectsWatcher();
 
 if (!process.send) {
-  console.log("Not running as child process. Throwing.");
   throw new Error("Must be run as a child process!");
 }
 
 process.removeAllListeners("uncaughtException");
 
-process.on("unhandledRejection", (err) => {
-  console.log(err);
-  process.send({type: "error", data: copyErrorFields(err)});
+process.on("unhandledRejection", err => {
+  process.send({ type: "error", data: copyErrorFields(err) });
 });
 
-process.on("uncaughtException", (err) => {
-  console.log(err);
-  process.send({type: "error", data: copyErrorFields(err)});
+process.on("uncaughtException", err => {
+  process.send({ type: "error", data: copyErrorFields(err) });
 });
 
 // Subscribe and forward watcher events
 const watcherEvents = [
   "contract-transaction",
   "contract-event",
-  "project-details-update"
+  "project-details-update",
 ];
-watcherEvents.forEach((eventName) => {
-  watcher.on(eventName, (data) => {
+watcherEvents.forEach(eventName => {
+  watcher.on(eventName, data => {
     process.send({
       type: eventName,
-      data: data
+      data: data,
     });
   });
 });
 
 process.on("message", async function(message) {
-  switch(message.type) {
+  switch (message.type) {
     case "web3-provider": {
       web3Host = message.data;
       watcher.setWeb3(web3Host);
@@ -50,13 +47,13 @@ process.on("message", async function(message) {
 
       process.send({
         type: "watcher-stopped",
-        data: null
+        data: null,
       });
 
       break;
     }
     case "project-details-request": {
-      let response = getProjectDetails(message.data.file);
+      let response = await getProjectDetails(message.data.file);
 
       if (typeof response.error === "undefined") {
         response = await watcher.add(response, message.data.networkId);
@@ -64,7 +61,7 @@ process.on("message", async function(message) {
 
       process.send({
         type: "project-details-response",
-        data: response
+        data: response,
       });
 
       break;
@@ -75,28 +72,49 @@ process.on("message", async function(message) {
     }
     case "decode-contract-request": {
       const { contract, contracts, block } = message.data;
-      const state = web3Host ? await DecodeHelpers.getContractState(contract, contracts, web3Host, block) : {};
+      const state = web3Host
+        ? await DecodeHelpers.getContractState(
+            contract,
+            contracts,
+            web3Host,
+            block,
+          )
+        : {};
       process.send({
         type: "decode-contract-response",
-        data: state
+        data: state,
       });
       break;
     }
     case "decode-event-request": {
       const { contract, contracts, log } = message.data;
-      let decodedLog = web3Host ? await DecodeHelpers.getDecodedEvent(contract, contracts, web3Host, log) : {};
+      let decodedLog = web3Host
+        ? await DecodeHelpers.getDecodedEvent(
+            contract,
+            contracts,
+            web3Host,
+            log,
+          )
+        : {};
       process.send({
         type: "decode-event-response",
-        data: decodedLog
+        data: decodedLog,
       });
       break;
     }
     case "decode-transaction-request": {
       const { contract, contracts, transaction } = message.data;
-      let decodedData = web3Host ? await DecodeHelpers.getDecodedTransaction(contract, contracts, web3Host, transaction) : {};
+      let decodedData = web3Host
+        ? await DecodeHelpers.getDecodedTransaction(
+            contract,
+            contracts,
+            web3Host,
+            transaction,
+          )
+        : {};
       process.send({
         type: "decode-transaction-response",
-        data: decodedData
+        data: decodedData,
       });
       break;
     }
@@ -104,16 +122,16 @@ process.on("message", async function(message) {
 });
 
 function copyErrorFields(e) {
-  let err = Object.assign({}, e)
+  let err = Object.assign({}, e);
 
   // I think these properties aren't enumerable on Error objects, so we copy
   // them manually if we don't do this, they aren't passed via IPC back to the
   // main process
-  err.message = e.message
-  err.stack = e.stack
-  err.name = e.name
+  err.message = e.message;
+  err.stack = e.stack;
+  err.name = e.name;
 
-  return err
+  return err;
 }
 
-process.send({type: "process-started"});
+process.send({ type: "process-started" });

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -17,9 +17,15 @@ async function get(projectFile) {
       const options = {
         stdio: ["pipe", "pipe", "pipe", "ipc"],
       };
-      let child = child_process.spawn("node", args, options);
+      const child = child_process.spawn("node", args, options);
       child.on("error", error => {
-        throw new Error(error);
+        if (error.code === "ENOENT") {
+          throw new Error(
+            "Could not find 'node'. NodeJS is required to be installed to link Truffle projects.",
+          );
+        } else {
+          throw new Error(error);
+        }
       });
       child.stderr.on("data", data => {
         throw new Error(data);

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -1,44 +1,58 @@
-const fs = require("fs");
 const path = require("path");
+const child_process = require("child_process");
 const TruffleConfig = require("truffle-config");
 
-function get(projectFile) {
+async function get(projectFile) {
   const configFileDirectory = path.dirname(projectFile);
   const name = path.basename(configFileDirectory);
-  if (!fs.existsSync(projectFile)) {
-    return {
-      name,
-      configFile: projectFile,
-      error: "project-does-not-exist"
-    };
-  }
-  else if (path.basename(projectFile).match(/^truffle(-config)?.js$/) === null) {
-    return {
-      name,
-      configFile: projectFile,
-      error: "invalid-project-file"
-    };
-  }
-  else {
-    let config = new TruffleConfig(configFileDirectory, configFileDirectory, "ganache");
-    const output = require(projectFile);
-    config.merge(output);
 
-    let contracts = [];
+  return new Promise((resolve, reject) => {
+    try {
+      const projectLoaderPath = path.join(
+        __dirname,
+        "../truffle-project-loader",
+        "index.js",
+      );
+      const args = [projectLoaderPath, projectFile];
+      const options = {
+        stdio: ["pipe", "pipe", "pipe", "ipc"],
+      };
+      let child = child_process.spawn("node", args, options);
+      child.on("error", error => {
+        throw new Error(error);
+      });
+      child.stderr.on("data", data => {
+        throw new Error(data);
+      });
+      child.on("message", async output => {
+        let config = new TruffleConfig(
+          configFileDirectory,
+          configFileDirectory,
+          "ganache",
+        );
+        config.merge(output);
 
-    return {
-      name,
-      configFile: projectFile,
-      config: {
-        truffle_directory: config.truffle_directory,
-        build_directory: config.build_directory,
-        contracts_build_directory: config.contracts_build_directory
-      },
-      contracts
-    };
-  }
+        let contracts = [];
+
+        const response = {
+          name: name,
+          configFile: projectFile,
+          config: {
+            truffle_directory: config.truffle_directory,
+            build_directory: config.build_directory,
+            contracts_build_directory: config.contracts_build_directory,
+          },
+          contracts,
+        };
+
+        resolve(response);
+      });
+    } catch (e) {
+      reject(e);
+    }
+  });
 }
 
 module.exports = {
-  get
-}
+  get,
+};

--- a/src/truffle-project-loader/index.js
+++ b/src/truffle-project-loader/index.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+const path = require("path");
+
+if (process.argv.length < 3) {
+  throw new Error(
+    `The truffle-project-loader process requires atleast 3 arguments, received ${
+      process.argv.length
+    }.`,
+  );
+}
+
+const projectFile = process.argv[2];
+
+const configFileDirectory = path.dirname(projectFile);
+const name = path.basename(configFileDirectory);
+if (!fs.existsSync(projectFile)) {
+  process.send({
+    name,
+    configFile: projectFile,
+    error: "project-does-not-exist",
+  });
+} else if (
+  path.basename(projectFile).match(/^truffle(-config)?.js$/) === null
+) {
+  process.send({
+    name,
+    configFile: projectFile,
+    error: "invalid-project-file",
+  });
+} else {
+  const output = require(projectFile);
+
+  process.send(output);
+}


### PR DESCRIPTION
This PR fixes #1076 by using a separate process which uses the `span("node")` function instead of `fork()` for running the `require()` on a Truffle project. This will use the system-installed version of node rather than the packaged version that comes with electron.