### PR TITLE
Feature/manual prettify

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,22 @@
 module.exports = {
-  extends: ["prettier", "eslint:recommended"],
-  plugins: ["prettier"],
+  extends: ["prettier", "eslint:recommended", "plugin:react/recommended"],
+  plugins: ["prettier", "react"],
   parser: "babel-eslint",
   rules: {
     "prettier/prettier": [1, { trailingComma: "all" }],
     "no-console": "warn",
+    "react/prop-types": 0
   },
   env: {
     es6: true,
     browser: true,
-    node: true
+    node: true,
+    mocha: true
+  },
+  settings: {
+    react: {
+      version: "detect"
+    }
   }
 };
 

--- a/forge_hooks/afterPrune.js
+++ b/forge_hooks/afterPrune.js
@@ -14,7 +14,7 @@ function afterPrune(buildPath, electronVersion, platform, arch, callback) {
 
 var deleteFolderRecursive = function(dirPath) {
   if (fs.existsSync(dirPath)) {
-    fs.readdirSync(dirPath).forEach(function(file, index) {
+    fs.readdirSync(dirPath).forEach(function(file) {
       var curdirPath = path.join(dirPath, file);
       if (fs.lstatSync(curdirPath).isDirectory()) {
         // recurse

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,6 +932,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -7584,6 +7594,32 @@
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.12.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+      "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.6.2",
+        "resolve": "^1.9.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+          "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "eslint-scope": {
@@ -17022,6 +17058,15 @@
         }
       }
     },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
+      }
+    },
     "keccak": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
@@ -19059,6 +19104,18 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.6.1",
         "function-bind": "^1.1.0",
+        "has": "^1.0.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
         "has": "^1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.4.0",
     "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-react": "^7.12.4",
     "husky": "^1.3.1",
     "jsdom": "^9.9.1",
     "lint-staged": "^8.1.0",

--- a/src/chain/chain.js
+++ b/src/chain/chain.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 var ganacheLib = require("ganache-core");
-var path = require("path");
 var logging = require("./logging");
 var pkg = require("../../package.json");
 
@@ -24,9 +23,7 @@ process.on("uncaughtException", err => {
 });
 
 var server;
-var provider;
 var blockInterval;
-var lastBlock;
 var dbLocation;
 
 function stopServer(callback) {
@@ -144,7 +141,7 @@ function startServer(options) {
       var accounts = state.accounts;
       var addresses = Object.keys(accounts);
 
-      addresses.forEach(function(address, index) {
+      addresses.forEach(function(address) {
         privateKeys[address] = accounts[address].secretKey.toString("hex");
       });
 

--- a/src/chain/logging.js
+++ b/src/chain/logging.js
@@ -1,5 +1,4 @@
 var path = require("path");
-var fs = require("fs");
 var fse = require("fs-extra");
 var padStart = require("lodash.padstart");
 

--- a/src/common/redux/auto-update/actions.js
+++ b/src/common/redux/auto-update/actions.js
@@ -3,14 +3,14 @@ const prefix = "UPDATE";
 
 export const SHOW_UPDATE_MODAL = `${prefix}/SHOW_UPDATE_MODAL`;
 export const showUpdateModal = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: SHOW_UPDATE_MODAL });
   };
 };
 
 export const CANCEL_UPDATE = `${prefix}/CANCEL_UPDATE`;
 export const cancelUpdate = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: CANCEL_UPDATE });
     ipcRenderer.send(CANCEL_UPDATE);
   };
@@ -42,7 +42,7 @@ export const setUpdateAvailable = function(
     releaseName = updateInfo.releaseName;
     releaseNotes = updateInfo.releaseNotes;
   }
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: UPDATE_AVAILABLE, newVersion, releaseName, releaseNotes });
   };
 };
@@ -66,7 +66,7 @@ export const setDownloadProgress = function(
     transferred = progressInfo.transferred;
   }
 
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({
       type: DOWNLOAD_PROGRESS,
       bytesPerSecond,
@@ -79,21 +79,21 @@ export const setDownloadProgress = function(
 
 export const UPDATE_DOWNLOADED = `${prefix}/UPDATE_DOWNLOADED`;
 export const setUpdateDownloaded = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: UPDATE_DOWNLOADED });
   };
 };
 
 export const DOWNLOAD_ERROR = `${prefix}/DOWNLOAD_ERROR`;
 export const setDownloadError = function(errorInfo) {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: DOWNLOAD_ERROR, errorInfo });
   };
 };
 
 export const BEGIN_DOWNLOADING = `${prefix}/BEGIN_DOWNLOADING`;
 export const beginDownloading = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: BEGIN_DOWNLOADING });
     ipcRenderer.send(BEGIN_DOWNLOADING);
   };
@@ -101,7 +101,7 @@ export const beginDownloading = function() {
 
 export const INSTALL_AND_RELAUNCH = `${prefix}/INSTALL_AND_RELAUNCH`;
 export const installAndRelaunch = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: INSTALL_AND_RELAUNCH });
     ipcRenderer.send(INSTALL_AND_RELAUNCH);
   };

--- a/src/common/redux/config/actions.js
+++ b/src/common/redux/config/actions.js
@@ -10,7 +10,7 @@ export function showConfigScreen(tab) {
 
 export const SET_SETTINGS = `${prefix}/SET_SETTINGS`;
 export const setSettings = function(globalSettings, workspaceSettings) {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     // Save settings to the store
     dispatch({
       type: SET_SETTINGS,
@@ -22,7 +22,7 @@ export const setSettings = function(globalSettings, workspaceSettings) {
 
 export const REQUEST_SAVE_SETTINGS = `${prefix}/REQUEST_SAVE_SETTINGS`;
 export const requestSaveSettings = function(globalSettings, workspaceSettings) {
-  return function(dispatch, getState) {
+  return function() {
     ipcRenderer.send(REQUEST_SAVE_SETTINGS, globalSettings, workspaceSettings);
   };
 };

--- a/src/common/redux/core/actions.js
+++ b/src/common/redux/core/actions.js
@@ -35,14 +35,14 @@ export function requestServerRestart() {
 
 export const SHOW_TITLE_SCREEN = `${prefix}/SHOW_TITLE_SCREEN`;
 export function showTitleScreen() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch(push("/title"));
   };
 }
 
 export const SHOW_HOME_SCREEN = `${prefix}/SHOW_HOME_SCREEN`;
 export function showHomeScreen() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch(push("/home"));
   };
 }
@@ -81,7 +81,7 @@ export const getGasLimit = function() {
   };
 };
 
-export const setBlockNumberToLatest = function(number) {
+export const setBlockNumberToLatest = function() {
   return async function(dispatch, getState) {
     const blockNumber = await web3ActionCreator(
       dispatch,
@@ -97,7 +97,7 @@ export const setBlockNumberToLatest = function(number) {
 
 export const SET_BLOCK_NUMBER = `${prefix}/SET_BLOCK_NUMBER`;
 export const setBlockNumber = function(number) {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: SET_BLOCK_NUMBER, number });
 
     // Refresh our accounts if the block changed.

--- a/src/common/redux/core/reducers.js
+++ b/src/common/redux/core/reducers.js
@@ -1,8 +1,5 @@
 import * as Core from "./actions";
 
-const MAX_BLOCKS = 10;
-const MAX_TRANSACTIONS = 10;
-
 const initialState = {
   started: false,
   isMining: true,

--- a/src/common/redux/events/actions.js
+++ b/src/common/redux/events/actions.js
@@ -81,7 +81,7 @@ export const requestPage = function(startBlockNumber, endBlockNumber) {
       if (cache && cache.contract) {
         const contract = cache.contract;
         const projectContracts = projects[contract.projectIndex].contracts;
-        const decodedLog = await new Promise((resolve, reject) => {
+        const decodedLog = await new Promise(resolve => {
           // TODO: there's a better way to do this to not have to send `contract` and `contracts` every time
           ipcRenderer.once(GET_DECODED_EVENT, (event, decodedLog) => {
             resolve(decodedLog);
@@ -190,7 +190,7 @@ export const getDecodedEvent = function(transactionHash, logIndex) {
     }
 
     if (contract && isSubscribedTopic) {
-      event.decodedLog = await new Promise((resolve, reject) => {
+      event.decodedLog = await new Promise(resolve => {
         // TODO: there's a better way to do this to not have to send `contract` and `contracts` every time
         ipcRenderer.once(GET_DECODED_EVENT, (event, decodedLog) => {
           resolve(decodedLog);

--- a/src/common/redux/middleware/analytics/engines/GoogleAnalytics.js
+++ b/src/common/redux/middleware/analytics/engines/GoogleAnalytics.js
@@ -66,35 +66,35 @@ function SystemErrorEvent(category, detail) {
   return e;
 }
 
-function RPCRequestStartedEvent(payload) {
-  return {
-    category: "rpc",
-    action: "started",
-    label: payload.method || "(unknown method)",
-    value: payload.params ? payload.params.length : 0,
-  };
-}
+// function RPCRequestStartedEvent(payload) {
+//   return {
+//     category: "rpc",
+//     action: "started",
+//     label: payload.method || "(unknown method)",
+//     value: payload.params ? payload.params.length : 0,
+//   };
+// }
 
-function RPCRequestSucceededEvent(payload) {
-  return {
-    category: "rpc",
-    action: "succeeded",
-    label: payload.method || "(unknown method)",
-  };
-}
+// function RPCRequestSucceededEvent(payload) {
+//   return {
+//     category: "rpc",
+//     action: "succeeded",
+//     label: payload.method || "(unknown method)",
+//   };
+// }
 
-function RPCRequestFailedEvent(payload) {
-  return {
-    category: "rpc",
-    action: "failed",
-    label: payload.method || "(unknown method)",
-  };
-}
+// function RPCRequestFailedEvent(payload) {
+//   return {
+//     category: "rpc",
+//     action: "failed",
+//     label: payload.method || "(unknown method)",
+//   };
+// }
 
-function RPCRequestStatusFailureEvent(payload) {
-  return {
-    category: "error",
-    action: "tx-status-failure",
-    label: payload.method || "(unknown method)",
-  };
-}
+// function RPCRequestStatusFailureEvent(payload) {
+//   return {
+//     category: "error",
+//     action: "tx-status-failure",
+//     label: payload.method || "(unknown method)",
+//   };
+// }

--- a/src/common/redux/middleware/analytics/index.js
+++ b/src/common/redux/middleware/analytics/index.js
@@ -4,7 +4,7 @@ const engines = [GoogleAnalytics];
 
 export function processAction({ getState }) {
   return next => action => {
-    engines.forEach((engine, index) => {
+    engines.forEach(engine => {
       engine.process(action, getState());
     });
 
@@ -15,7 +15,7 @@ export function processAction({ getState }) {
 }
 
 export function processPage(path, state) {
-  engines.forEach((engine, index) => {
+  engines.forEach(engine => {
     engine.processPage(path, state);
   });
 }

--- a/src/common/redux/request-cache/reducers.js
+++ b/src/common/redux/request-cache/reducers.js
@@ -7,7 +7,7 @@ const initialState = {};
 const HARD_CACHED = {
   eth_accounts: true,
   eth_gasPrice: true,
-  eth_getBlockByNumber: (blockNumber, includeTransactions) => {
+  eth_getBlockByNumber: blockNumber => {
     return blockNumber != "latest" && blockNumber != "pending";
   },
   eth_getBlockTransactionCountByNumber: blockNumber => {

--- a/src/common/redux/search/actions.js
+++ b/src/common/redux/search/actions.js
@@ -1,8 +1,6 @@
 import { web3Request } from "../web3/helpers/Web3ActionCreator";
 import { push } from "react-router-redux";
 
-const prefix = "SEARCH";
-
 export const query = function(message) {
   return async function(dispatch, getState) {
     // do nothing if user submits empty search string

--- a/src/common/redux/transactions/actions.js
+++ b/src/common/redux/transactions/actions.js
@@ -195,7 +195,7 @@ export const showTransaction = function(hash) {
 
     if (contract) {
       for (let j = 0; j < events.length; j++) {
-        events[j].decodedLog = await new Promise((resolve, reject) => {
+        events[j].decodedLog = await new Promise(resolve => {
           // TODO: there's a better way to do this to not have to send `contract` and `contracts` every time
           ipcRenderer.once(GET_DECODED_EVENT, (event, decodedLog) => {
             resolve(decodedLog);
@@ -209,7 +209,7 @@ export const showTransaction = function(hash) {
         });
       }
 
-      decodedData = await new Promise((resolve, reject) => {
+      decodedData = await new Promise(resolve => {
         // TODO: there's a better way to do this to not have to send `contract` and `contracts` every time
         ipcRenderer.once(
           GET_DECODED_TRANSACTION_INPUT,

--- a/src/common/redux/web3/helpers/ReduxWeb3Provider.js
+++ b/src/common/redux/web3/helpers/ReduxWeb3Provider.js
@@ -6,7 +6,6 @@ import EventEmitter from "events";
 class ReduxWeb3Provider extends EventEmitter {
   constructor(url, dispatch, getState) {
     super();
-    const self = this;
 
     let parsedURL = new URL(url);
     let scheme = parsedURL.protocol.toLowerCase();
@@ -24,7 +23,6 @@ class ReduxWeb3Provider extends EventEmitter {
   }
 
   send(payload, callback) {
-    var sendMethod = this.provider.sendAsync || this.provider.send;
     var cached = RequestCache.checkCache(payload, this.getState);
 
     if (cached) {

--- a/src/common/redux/workspaces/actions.js
+++ b/src/common/redux/workspaces/actions.js
@@ -5,7 +5,7 @@ import {
   web3CleanUpHelper,
   web3ActionCreator,
 } from "../web3/helpers/Web3ActionCreator";
-import { REQUEST_SERVER_RESTART, showTitleScreen } from "../core/actions";
+import { REQUEST_SERVER_RESTART } from "../core/actions";
 import { GET_DECODED_EVENT } from "../events/actions";
 
 const prefix = "WORKSPACES";
@@ -37,7 +37,7 @@ export const closeWorkspace = function() {
 
 export const OPEN_WORKSPACE = `${prefix}/OPEN_WORKSPACE`;
 export const openWorkspace = function(name) {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch(push("/loader"));
     dispatch({ type: OPEN_WORKSPACE, name });
     ipcRenderer.send(OPEN_WORKSPACE, name);
@@ -45,7 +45,7 @@ export const openWorkspace = function(name) {
 };
 
 export const openDefaultWorkspace = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch(push("/loader"));
     dispatch({ type: OPEN_WORKSPACE, name: null });
     ipcRenderer.send(OPEN_WORKSPACE, null);
@@ -54,7 +54,7 @@ export const openDefaultWorkspace = function() {
 
 export const OPEN_NEW_WORKSPACE_CONFIG = `${prefix}/OPEN_NEW_WORKSPACE_CONFIG`;
 export const openNewWorkspaceConfig = function() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch(push("/loader"));
     ipcRenderer.send(OPEN_NEW_WORKSPACE_CONFIG);
   };
@@ -75,7 +75,7 @@ export const saveWorkspace = function(name) {
 
 export const DELETE_WORKSPACE = `${prefix}/DELETE_WORKSPACE`;
 export const deleteWorkspace = function(name) {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: DELETE_WORKSPACE, name });
 
     ipcRenderer.send(DELETE_WORKSPACE, name);
@@ -166,7 +166,7 @@ export const getContractDetails = function(data) {
           }
           log.timestamp = blockTimestamps[log.blockNumber];
 
-          const decodedLog = await new Promise((resolve, reject) => {
+          const decodedLog = await new Promise(resolve => {
             // TODO: there's a better way to do this to not have to send `contract` and `contracts` every time
             ipcRenderer.once(GET_DECODED_EVENT, (event, decodedLog) => {
               resolve(decodedLog);
@@ -184,7 +184,7 @@ export const getContractDetails = function(data) {
       }
     }
 
-    const state = await new Promise((resolve, reject) => {
+    const state = await new Promise(resolve => {
       ipcRenderer.once(GET_CONTRACT_DETAILS, (event, state) => {
         resolve(state);
       });

--- a/src/common/services/AutoUpdateService.js
+++ b/src/common/services/AutoUpdateService.js
@@ -1,5 +1,5 @@
 import EventEmitter from "events";
-import { app, protocol, ipcMain } from "electron";
+import { app } from "electron";
 import { autoUpdater } from "benjamincburns-forked-electron-updater";
 import { CancellationToken } from "builder-util-runtime";
 import path from "path";
@@ -88,7 +88,7 @@ export default class AutoUpdateService extends EventEmitter {
       if (promise.catch) {
         // avoid unhandled promise rejection
         // error will be reported from the `error` event handler
-        promise.catch(err => {});
+        promise.catch(() => {});
       }
     }
   }
@@ -104,7 +104,7 @@ export default class AutoUpdateService extends EventEmitter {
       if (promise.catch) {
         // avoid unhandled promise rejection
         // error will be reported from the `error` event handler
-        promise.catch(err => {});
+        promise.catch(() => {});
       }
     }
   }
@@ -124,7 +124,7 @@ export default class AutoUpdateService extends EventEmitter {
       if (promise.catch) {
         // avoid unhandled promise rejection
         // error will be reported from the `error` event handler
-        promise.catch(err => {});
+        promise.catch(() => {});
       }
     }
   }

--- a/src/common/services/ChainService.js
+++ b/src/common/services/ChainService.js
@@ -77,8 +77,8 @@ class ChainService extends EventEmitter {
     }
   }
 
-  stopServer(options) {
-    return new Promise((resolve, reject) => {
+  stopServer() {
+    return new Promise(resolve => {
       this.once("server-stopped", () => {
         resolve();
       });
@@ -93,7 +93,7 @@ class ChainService extends EventEmitter {
   }
 
   getDbLocation() {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.once("db-location", location => {
         resolve(location);
       });

--- a/src/common/services/TruffleIntegrationService.js
+++ b/src/common/services/TruffleIntegrationService.js
@@ -67,7 +67,7 @@ class TruffleIntegrationService extends EventEmitter {
   }
 
   async stopWatching() {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.once("watcher-stopped", () => {
         resolve();
       });

--- a/src/main/init/AutoUpdate.js
+++ b/src/main/init/AutoUpdate.js
@@ -33,7 +33,7 @@ export function initAutoUpdates(settings, mainWindow) {
   autoUpdateService.on("download-progress", progressInfo => {
     mainWindow.webContents.send(AutoUpdate.DOWNLOAD_PROGRESS, progressInfo);
   });
-  autoUpdateService.on("update-downloaded", path => {
+  autoUpdateService.on("update-downloaded", () => {
     mainWindow.webContents.send(AutoUpdate.UPDATE_DOWNLOADED);
     setTimeout(() => {
       autoUpdateService.installAndRelaunch();
@@ -45,20 +45,20 @@ export function initAutoUpdates(settings, mainWindow) {
       stack: errorInfo.stack || null,
     });
   });
-  ipcMain.on(AutoUpdate.CANCEL_UPDATE, event => {
+  ipcMain.on(AutoUpdate.CANCEL_UPDATE, () => {
     autoUpdateService.cancelUpdate();
   });
-  ipcMain.on(AutoUpdate.BEGIN_DOWNLOADING, event => {
+  ipcMain.on(AutoUpdate.BEGIN_DOWNLOADING, () => {
     autoUpdateService.downloadUpdate();
   });
-  ipcMain.on(AutoUpdate.INSTALL_AND_RELAUNCH, event => {
+  ipcMain.on(AutoUpdate.INSTALL_AND_RELAUNCH, () => {
     autoUpdateService.installAndRelaunch();
   });
 
   autoUpdateService.checkForUpdates();
 }
 
-function getAutoUpdateServiceOptions(settings) {
+function getAutoUpdateServiceOptions() {
   let allowPrerelease = pkg.version.match(/-beta/) !== null;
 
   return {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -31,7 +31,6 @@ import {
   SAVE_WORKSPACE,
   DELETE_WORKSPACE,
   SET_CURRENT_WORKSPACE,
-  CONTRACT_DEPLOYED,
   CONTRACT_TRANSACTION,
   CONTRACT_EVENT,
   GET_CONTRACT_DETAILS,
@@ -58,7 +57,6 @@ import { ADD_LOG_LINES } from "../common/redux/logs/actions";
 
 import ChainService from "../common/services/ChainService";
 import GlobalSettings from "./types/settings/GlobalSettings";
-import Workspace from "./types/workspaces/Workspace";
 import WorkspaceManager from "./types/workspaces/WorkspaceManager";
 import GoogleAnalyticsService from "../common/services/GoogleAnalyticsService";
 import TruffleIntegrationService from "../common/services/TruffleIntegrationService.js";
@@ -66,8 +64,7 @@ import TruffleIntegrationService from "../common/services/TruffleIntegrationServ
 let menu;
 let template;
 let mainWindow = null;
-let testRpcService = null;
-let consoleService = null // eslint-disable-line
+let consoleService = null; // eslint-disable-line
 
 // If you want to test out error handling
 // setTimeout(() => {
@@ -407,7 +404,7 @@ app.on("ready", () => {
       }
     });
 
-    ipcMain.on(CLOSE_WORKSPACE, async event => {
+    ipcMain.on(CLOSE_WORKSPACE, async () => {
       if (workspace) {
         if (truffleIntegration) {
           await truffleIntegration.stopWatching();
@@ -500,7 +497,7 @@ app.on("ready", () => {
       }
     });
 
-    ipcMain.on(OPEN_NEW_WORKSPACE_CONFIG, async event => {
+    ipcMain.on(OPEN_NEW_WORKSPACE_CONFIG, async () => {
       if (truffleIntegration) {
         await truffleIntegration.stopWatching();
       }

--- a/src/main/types/json/JsonWithKeyPaths.js
+++ b/src/main/types/json/JsonWithKeyPaths.js
@@ -54,8 +54,6 @@ class JsonWithKeyPaths {
   }
 
   has(keyPath) {
-    const keys = keyPath.split(".");
-
     return typeof this.get(keyPath) !== "undefined";
   }
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -2,14 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { AppContainer } from "react-hot-loader";
 
-import { applyMiddleware } from "redux";
 import { Provider } from "react-redux";
-import { Router, Route, IndexRoute, hashHistory } from "react-router";
+import { Router, Route, hashHistory } from "react-router";
 
 import RootReducer from "../common/redux/reducer";
 
 import createStore from "./init/store/createStore";
-import syncStore from "./init/store/syncStore";
 import { initRenderer } from "./init/index";
 
 import AppShell from "./screens/appshell/AppShell";

--- a/src/renderer/init/AutoUpdate.js
+++ b/src/renderer/init/AutoUpdate.js
@@ -1,14 +1,10 @@
 import { ipcRenderer } from "electron";
 
 import {
-  UPDATE_CHECK_IN_PROGRESS,
-  UPDATE_CHECK_COMPLETE,
   UPDATE_AVAILABLE,
   DOWNLOAD_PROGRESS,
   UPDATE_DOWNLOADED,
   DOWNLOAD_ERROR,
-  setUpdateCheckInProgress,
-  setUpdateCheckComplete,
   setUpdateAvailable,
   setDownloadProgress,
   setUpdateDownloaded,
@@ -22,7 +18,7 @@ export function initAutoUpdates(store) {
   ipcRenderer.on(DOWNLOAD_PROGRESS, (event, progressInfo) => {
     store.dispatch(setDownloadProgress(progressInfo));
   });
-  ipcRenderer.on(UPDATE_DOWNLOADED, (event, path) => {
+  ipcRenderer.on(UPDATE_DOWNLOADED, () => {
     store.dispatch(setUpdateDownloaded());
   });
   ipcRenderer.on(DOWNLOAD_ERROR, (event, errorInfo) => {

--- a/src/renderer/init/Config.js
+++ b/src/renderer/init/Config.js
@@ -14,7 +14,7 @@ import {
 } from "../../common/redux/config/actions";
 
 export function initConfig(store) {
-  ipcRenderer.on(SHOW_CONFIG_SCREEN, event => {
+  ipcRenderer.on(SHOW_CONFIG_SCREEN, () => {
     store.dispatch(showConfigScreen());
   });
 
@@ -26,7 +26,7 @@ export function initConfig(store) {
     store.dispatch(clearSettingError(key));
   });
 
-  ipcRenderer.on(CLEAR_ALL_SETTING_ERRORS, event => {
+  ipcRenderer.on(CLEAR_ALL_SETTING_ERRORS, () => {
     store.dispatch(clearAllSettingErrors());
   });
 

--- a/src/renderer/init/Core.js
+++ b/src/renderer/init/Core.js
@@ -89,7 +89,7 @@ export function initCore(store) {
     store.dispatch(setKeyData(data.mnemonic, data.hdPath, data.privateKeys));
   });
 
-  ipcRenderer.on(SHOW_HOME_SCREEN, event => {
+  ipcRenderer.on(SHOW_HOME_SCREEN, () => {
     store.dispatch(showHomeScreen());
   });
 }

--- a/src/renderer/init/store/syncStore.js
+++ b/src/renderer/init/store/syncStore.js
@@ -1,6 +1,6 @@
 import { hashHistory } from "react-router";
 
-export default async function(store) {
+export default async function() {
   return new Promise(resolve => {
     resolve(hashHistory);
   });

--- a/src/renderer/screens/appshell/TopNavbar.js
+++ b/src/renderer/screens/appshell/TopNavbar.js
@@ -15,8 +15,6 @@ import {
 import { clearLogLines } from "../../../common/redux/logs/actions";
 
 import ModalDetails from "../../components/modal/ModalDetails";
-import Spinner from "../../components/spinner/Spinner";
-import MDSpinner from "react-md-spinner";
 import OnlyIf from "../../components/only-if/OnlyIf";
 import StatusIndicator from "../../components/status-indicator/StatusIndicator";
 import UpdateNotification from "../auto-update/UpdateNotification";
@@ -43,27 +41,27 @@ class TopNavbar extends Component {
     };
   }
 
-  _handleStopMining(e) {
+  _handleStopMining() {
     this.props.appStopMining();
   }
 
-  _handleStartMining(e) {
+  _handleStartMining() {
     this.props.appStartMining();
   }
 
-  _handleForceMine(e) {
+  _handleForceMine() {
     this.props.appForceMine();
   }
 
-  _handleMakeSnapshot(e) {
+  _handleMakeSnapshot() {
     this.props.appMakeSnapshot();
   }
 
-  _handleRevertSnapshot(e) {
+  _handleRevertSnapshot() {
     this.props.appRevertSnapshot(this.props.core.snapshots.length);
   }
 
-  _handleClearLogs(e) {
+  _handleClearLogs() {
     this.props.dispatch(clearLogLines());
   }
 
@@ -122,11 +120,11 @@ class TopNavbar extends Component {
     }
   }
 
-  handleWorkspacesPress(e) {
+  handleWorkspacesPress() {
     this.props.dispatch(closeWorkspace());
   }
 
-  handleSaveWorkspacePress(e) {
+  handleSaveWorkspacePress() {
     this.props.dispatch(saveWorkspace(moniker.choose()));
   }
 

--- a/src/renderer/screens/auto-update/UpdateNotification.js
+++ b/src/renderer/screens/auto-update/UpdateNotification.js
@@ -12,7 +12,7 @@ class UpdateNotification extends Component {
     this.state = {};
   }
 
-  handleUpdateClick(e) {
+  handleUpdateClick() {
     this.props.dispatch(showUpdateModal());
   }
 

--- a/src/renderer/screens/config/ConfigScreen.js
+++ b/src/renderer/screens/config/ConfigScreen.js
@@ -82,7 +82,7 @@ class ConfigScreen extends PureComponent {
     );
   }
 
-  handleCancelPressed = e => {
+  handleCancelPressed = () => {
     if (this.state.restartOnCancel) {
       // we are in the config screen because of a system error
       // restart application without saving settings if the user hit cancel
@@ -117,7 +117,7 @@ class ConfigScreen extends PureComponent {
     });
   };
 
-  handleMakeTabActive = (index, event) => {
+  handleMakeTabActive = index => {
     this.setState({
       activeIndex: index,
     });

--- a/src/renderer/screens/config/ConfigScreens/AccountsScreen.js
+++ b/src/renderer/screens/config/ConfigScreens/AccountsScreen.js
@@ -32,8 +32,6 @@ class AccountsScreen extends Component {
 
   toggleAccountsLocked = () => {
     var toggleState = !this.state.accountsLocked;
-    var unlocked_accounts = this.props.config.settings.workspace.server
-      .unlocked_accounts;
     var total_accounts = this.props.config.settings.workspace.server
       .total_accounts;
 

--- a/src/renderer/screens/config/ConfigScreens/ChainScreen.js
+++ b/src/renderer/screens/config/ConfigScreens/ChainScreen.js
@@ -18,12 +18,12 @@ const VALIDATIONS = {
   },
 };
 
-const FORK_URLS = {
-  mainnet: "https://mainnet.infura.io/ganache",
-  ropsten: "https://ropsten.infura.io/ganache",
-  kovan: "https://kovan.infura.io/ganache",
-  rinkeby: "https://rinkeby.infura.io/ganache",
-};
+// const FORK_URLS = {
+//   mainnet: "https://mainnet.infura.io/ganache",
+//   ropsten: "https://ropsten.infura.io/ganache",
+//   kovan: "https://kovan.infura.io/ganache",
+//   rinkeby: "https://rinkeby.infura.io/ganache",
+// };
 
 class ChainScreen extends Component {
   constructor(props) {

--- a/src/renderer/screens/config/ConfigScreens/ServerScreen.js
+++ b/src/renderer/screens/config/ConfigScreens/ServerScreen.js
@@ -79,8 +79,8 @@ class ServerScreen extends Component {
   };
 
   render() {
-    const ganachePortStatus = { status: "clear" };
-    const portIsBlocked = false;
+    // const ganachePortStatus = { status: "clear" };
+    // const portIsBlocked = false;
     // const { ganachePortStatus } = this.props.testRpcState
     // const portIsBlocked =
     //   ganachePortStatus.status === 'blocked' &&

--- a/src/renderer/screens/events/RecentEvents.js
+++ b/src/renderer/screens/events/RecentEvents.js
@@ -7,7 +7,7 @@ import EventList from "./EventList";
 import * as Events from "../../../common/redux/events/actions";
 
 class RecentEvents extends Component {
-  componentDidUpdate(prevProps, prevState, snapshot) {
+  componentDidUpdate(prevProps) {
     // If the scroll position changed...
     if (
       this.props.appshell.scrollPosition != prevProps.appshell.scrollPosition

--- a/src/renderer/screens/logs/LogContainer.js
+++ b/src/renderer/screens/logs/LogContainer.js
@@ -3,7 +3,7 @@ import { Scrollbars } from "react-custom-scrollbars";
 import connect from "../helpers/connect";
 
 class LogContainer extends Component {
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps) {
     return nextProps.logs.lines.length !== this.props.logs.lines.length;
   }
 

--- a/src/renderer/screens/startup/HomeScreen.js
+++ b/src/renderer/screens/startup/HomeScreen.js
@@ -61,11 +61,11 @@ class HomeScreen extends Component {
     this.props.dispatch(ModalDetails.actions.setModalError(modalDetails));
   }
 
-  handleQuickstartPress(e) {
+  handleQuickstartPress() {
     this.props.dispatch(openDefaultWorkspace());
   }
 
-  handleNewWorkspacePress(e) {
+  handleNewWorkspacePress() {
     this.props.dispatch(openNewWorkspaceConfig());
   }
 
@@ -74,7 +74,7 @@ class HomeScreen extends Component {
     const hasWorkspaces = this.props.workspaces.names.length;
 
     if (hasWorkspaces) {
-      workspaces = this.props.workspaces.names.map((workspaceName, i) => {
+      workspaces = this.props.workspaces.names.map(workspaceName => {
         return (
           <li key={workspaceName}>
             <button onClick={this.selectWorkspace.bind(this)}>

--- a/src/truffle-integration/projectsWatcher.js
+++ b/src/truffle-integration/projectsWatcher.js
@@ -43,7 +43,7 @@ class ProjectsWatcher extends EventEmitter {
 
     this.blockHeaderSubscription = this.web3.eth.subscribe(
       "newBlockHeaders",
-      (error, result) => {
+      error => {
         if (error) {
           throw error;
         }
@@ -63,7 +63,7 @@ class ProjectsWatcher extends EventEmitter {
         fromBlock: null,
         topics: null,
       },
-      (error, result) => {
+      error => {
         if (error) {
           throw error;
         }


### PR DESCRIPTION
Continuation of #1087 for resolution of #1085 

This PR is for all of my manual edits. Trimmed down the remaining ~300 lint errors left over from the auto prettify to about 40.

Pretty much only did `no-unused-vars` and a couple of other minor ones that don't involve any logical  or graphical refactors to lean on the safe side.

The remaining lint errors are mostly `react/no-direct-mutation-state`, `react/no-string-refs`, `react/no-unescaped-entities`, etc.

EDIT: You can refer to this [commit range](https://github.com/trufflesuite/ganache/pull/1088/files/8b9475018e3f731d65a26a3c1f468ac15ade6651..541934518d7259ad30b06a45d8a6d9deca8ed5de) for ease of reading. I omitted 8b94750 (the auto prettify)