### PR TITLE
Fix Google Analytics Reporting for 2.x

### DIFF
--- a/src/common/redux/middleware/analytics/engines/GoogleAnalytics.js
+++ b/src/common/redux/middleware/analytics/engines/GoogleAnalytics.js
@@ -9,46 +9,53 @@ import {
 } from "../../../web3/helpers/ReduxWeb3Provider";
 
 export function processPage(pathname, state) {
-  const GoogleAnalytics = new GoogleAnalyticsService();
-  GoogleAnalytics.setup(
-    state.config.settings.googleAnalyticsTracking,
-    state.config.settings.uuid,
-  );
+  if (state.config.settings.global) {
+    const GoogleAnalytics = new GoogleAnalyticsService();
+    GoogleAnalytics.setup(
+      state.config.settings.global.googleAnalyticsTracking,
+      state.config.settings.global.uuid,
+    );
 
-  GoogleAnalytics.reportPageview(pathname);
-  const segment = pathname.split("/")[1] || "dashboard";
-  GoogleAnalytics.reportScreenview(segment);
+    GoogleAnalytics.reportPageview(pathname);
+    const segment = pathname.split("/")[1] || "dashboard";
+    GoogleAnalytics.reportScreenview(segment);
+  }
 }
 
 export function process(action, state) {
-  const GoogleAnalytics = new GoogleAnalyticsService();
-  GoogleAnalytics.setup(
-    state.config.settings.googleAnalyticsTracking,
-    state.config.settings.uuid,
-  );
+  if (state.config.settings.global) {
+    const GoogleAnalytics = new GoogleAnalyticsService();
+    GoogleAnalytics.setup(
+      state.config.settings.global.googleAnalyticsTracking,
+      state.config.settings.global.uuid,
+    );
 
-  switch (action.type) {
-    case SET_SYSTEM_ERROR: {
-      GoogleAnalytics.reportEvent(
-        SystemErrorEvent(action.category, action.detail),
-      );
-      break;
-    }
-    case RPC_REQUEST_STARTED: {
-      // GoogleAnalytics.reportEvent(RPCRequestStartedEvent(action.payload))
-      break;
-    }
-    case RPC_REQUEST_SUCCEEDED: {
-      // GoogleAnalytics.reportEvent(RPCRequestSucceededEvent(action.payload))
+    switch (action.type) {
+      case SET_SYSTEM_ERROR: {
+        GoogleAnalytics.reportEvent(
+          SystemErrorEvent(action.category, action.detail),
+        );
+        break;
+      }
+      case RPC_REQUEST_STARTED: {
+        // Disabled due to hitting Google Analytics over our limits
+        // GoogleAnalytics.reportEvent(RPCRequestStartedEvent(action.payload))
+        break;
+      }
+      case RPC_REQUEST_SUCCEEDED: {
+        // Disabled due to hitting Google Analytics over our limits
+        // GoogleAnalytics.reportEvent(RPCRequestSucceededEvent(action.payload))
 
-      // if (action.result.status === '0x0' || action.result.status == 0) {
-      //   GoogleAnalytics.reportEvent(RPCRequestStatusFailureEvent(action.payload))
-      // }
-      break;
-    }
-    case RPC_REQUEST_FAILED: {
-      // GoogleAnalytics.reportEvent(RPCRequestFailedEvent(action.payload))
-      break;
+        // if (action.result.status === '0x0' || action.result.status == 0) {
+        //   GoogleAnalytics.reportEvent(RPCRequestStatusFailureEvent(action.payload))
+        // }
+        break;
+      }
+      case RPC_REQUEST_FAILED: {
+        // Disabled due to hitting Google Analytics over our limits
+        // GoogleAnalytics.reportEvent(RPCRequestFailedEvent(action.payload))
+        break;
+      }
     }
   }
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -103,7 +103,6 @@ app.on("ready", () => {
   // see https://github.com/electron/electron/issues/9179 for more info
 
   setTimeout(async () => {
-    const inProduction = process.env.NODE_ENV === "production";
     const width = screen.getPrimaryDisplay().bounds.width;
     const chain = new ChainService(app);
     const truffleIntegration = new TruffleIntegrationService();
@@ -449,7 +448,7 @@ app.on("ready", () => {
       } else {
         const workspaceSettings = workspace.settings.getAll();
         GoogleAnalytics.setup(
-          global.get("googleAnalyticsTracking") && inProduction,
+          global.get("googleAnalyticsTracking") && !isDevMode,
           workspaceSettings.uuid,
         );
         GoogleAnalytics.reportGenericUserData();


### PR DESCRIPTION
This PR is based off #1088 to prevent merge conflicts. I would consider this blocked by #1088

You can find the compare of the changes I made here: https://github.com/trufflesuite/ganache/compare/5419345...bug/fix-google-analytics

In 2.x, we changed `state.config.settings` to be split into `state.config.settings.workspace` and `state.config.settings.global`. The one place that the change was not updated was in the Google Analytics reporting.

For some reason `process.env.NODE_ENV` was reporting as `undefined`. This PR changes `main.js` to use `isDevMode` flag instead to enable Google Analytics for generic user data.

This PR fixes those problems