### PR TITLE
Fix/not linking truffle projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-mac": "electron-builder --mac",
     "build-windows": "electron-builder --win",
     "test": "npm run test-mocha",
-    "test-mocha": "mocha --compilers js:babel-register --check-leaks --globals _scratch,sanitizedData 'test/mocha/**/*.test.js'",
+    "test-mocha": "mocha --compilers js:babel-register --check-leaks --globals _scratch,sanitizedData 'test/mocha/**/*.test.js' 'src/**/*test.js' ",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-mac": "electron-builder --mac",
     "build-windows": "electron-builder --win",
     "test": "npm run test-mocha",
-    "test-mocha": "mocha --compilers js:babel-register --check-leaks --globals _scratch,sanitizedData 'test/mocha/**/*.test.js' 'src/**/*test.js' ",
+    "test-mocha": "mocha --compilers js:babel-register --check-leaks --globals _scratch,sanitizedData 'test/mocha/**/*.test.js' 'src/**/*.test.js' ",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/src/truffle-integration/__tests__/projectFsWatcherUtils.test.js
+++ b/src/truffle-integration/__tests__/projectFsWatcherUtils.test.js
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { getAncestorDirs } from "../projectFsWatcherUtils";
+
+describe("projectFsWatcherUtils", () => {
+  describe("getAncestorDirs", () => {
+    const truffle_directory = "/path/to/awesome/project";
+
+    it("returns a list of all ancestor dirs up to truffle_directory when contracts_build_directory is a child of truffle_directory", () => {
+      const contracts_build_directory = `${truffle_directory}/contracts`;
+      const dirs = getAncestorDirs(
+        truffle_directory,
+        contracts_build_directory,
+      );
+
+      assert.deepEqual(dirs, [truffle_directory]);
+    });
+
+    it("returns a list of all ancestor dirs up to truffle_directory when contracts_build_directory is a descendant of truffle_directory", () => {
+      const contracts_build_directory = `${truffle_directory}/build/contracts`;
+      const dirs = getAncestorDirs(
+        truffle_directory,
+        contracts_build_directory,
+      );
+
+      assert.deepEqual(dirs, [truffle_directory, `${truffle_directory}/build`]);
+    });
+
+    it("returns a list of all ancestor dirs when contracts_build_directory is not a descendent of truffle_directory", () => {
+      const contracts_build_directory = `/path/to/build/contracts`;
+      const dirs = getAncestorDirs(
+        truffle_directory,
+        contracts_build_directory,
+      );
+
+      assert.deepEqual(dirs, ["/", "/path", "/path/to", "/path/to/build"]);
+    });
+  });
+});

--- a/src/truffle-integration/projectFsWatcher.js
+++ b/src/truffle-integration/projectFsWatcher.js
@@ -5,6 +5,9 @@ const getProjectDetails = require("./projectDetails").get;
 const merge = require("lodash.merge");
 const { getAncestorDirs } = require("./projectFsWatcherUtils");
 
+/**
+ * Detects when there are new/changed/removed contract artifacts in contracts_build_directory
+ */
 class ProjectFsWatcher extends EventEmitter {
   constructor(project, networkId) {
     super();

--- a/src/truffle-integration/projectFsWatcher.js
+++ b/src/truffle-integration/projectFsWatcher.js
@@ -96,12 +96,14 @@ class ProjectFsWatcher extends EventEmitter {
   startWatchingDirs(dirs) {
     console.log(
       "startWatchingDirs",
-      this.project.config.truffle_directory,
+      path.basename(this.project.config.truffle_directory),
       dirs,
+      this.dirWatchers.length,
     );
-    this.stopWatchingDirs();
+    // this.stopWatchingDirs();
     const [head, ...tail] = dirs;
-    if (head) {
+    console.log(head, tail);
+    if (head && fs.existsSync(head)) {
       const watcher = fs.watch(
         head,
         { encoding: "utf8" },
@@ -114,7 +116,8 @@ class ProjectFsWatcher extends EventEmitter {
             this.startWatchingContracts();
           }
 
-          if (filename === path.basename(tail[0])) this.startWatchingDirs(tail);
+          if (tail[0] && filename === path.basename(tail[0]))
+            this.startWatchingDirs(tail);
         },
       );
       this.dirWatchers = [...this.dirWatchers, watcher];

--- a/src/truffle-integration/projectFsWatcher.js
+++ b/src/truffle-integration/projectFsWatcher.js
@@ -66,13 +66,20 @@ class ProjectFsWatcher extends EventEmitter {
     Object.keys(this.dirWatchers).forEach(dir => this.stopWatchingDir(dir));
   }
 
+  /**
+   * @param {string} dir The directory name
+   */
   stopWatchingDir(dir) {
     if (this.dirWatchers[dir]) {
       this.dirWatchers[dir].close();
+      // There's no object spread, so just delete the key
       delete this.dirWatchers[dir];
     }
   }
 
+  /**
+   * @param {string[]} dirs An array of directory names
+   */
   startWatchingDirs(dirs) {
     const [head, ...tail] = dirs;
 

--- a/src/truffle-integration/projectFsWatcher.js
+++ b/src/truffle-integration/projectFsWatcher.js
@@ -58,7 +58,6 @@ class ProjectFsWatcher extends EventEmitter {
 
       this.startWatchingParentDirectory();
     } else {
-      console.log("start new");
       this.configWatcher = fs.watch(
         this.project.configFile,
         { encoding: "utf8" },
@@ -100,14 +99,7 @@ class ProjectFsWatcher extends EventEmitter {
   }
 
   startWatchingDirs(dirs) {
-    console.log(
-      "startWatchingDirs",
-      path.basename(this.project.config.truffle_directory),
-      dirs,
-      Object.keys(this.dirWatchers),
-    );
     const [head, ...tail] = dirs;
-    console.log(head, tail);
 
     if (head) this.stopWatchingDir(head);
 
@@ -116,7 +108,6 @@ class ProjectFsWatcher extends EventEmitter {
         head,
         { encoding: "utf8" },
         (eventType, filename) => {
-          console.log("startWatchingDirs", eventType, filename);
           if (
             filename ===
             path.basename(this.project.config.contracts_build_directory)
@@ -137,14 +128,12 @@ class ProjectFsWatcher extends EventEmitter {
   }
 
   startWatchingParentDirectory() {
-    console.log(path.dirname(this.project.config.build_directory));
     this.stopWatchingParentDirectory();
 
     this.parentDirectoryWatcher = fs.watch(
       path.dirname(this.project.config.build_directory),
       { encoding: "utf8" },
       (eventType, filename) => {
-        console.log(eventType, filename);
         if (filename === path.basename(this.project.config.build_directory)) {
           this.startWatchingBuildDirectory();
         }
@@ -247,10 +236,6 @@ class ProjectFsWatcher extends EventEmitter {
   }
 
   startWatchingContracts() {
-    console.log(
-      "startWatchingContracts",
-      this.project.config.truffle_directory,
-    );
     this.stopWatchingContracts();
 
     if (fs.existsSync(this.project.config.contracts_build_directory)) {

--- a/src/truffle-integration/projectFsWatcher.js
+++ b/src/truffle-integration/projectFsWatcher.js
@@ -88,10 +88,14 @@ class ProjectFsWatcher extends EventEmitter {
     }
   }
 
+  stopWatchingDirs() {
+    Object.keys(this.dirWatchers).forEach(dir => this.stopWatchingDir(dir));
+  }
+
   stopWatchingDir(dir) {
     if (this.dirWatchers[dir]) {
       this.dirWatchers[dir].close();
-      this.dirWatchers[dir] = undefined;
+      delete this.dirWatchers[dir];
     }
   }
 

--- a/src/truffle-integration/projectFsWatcherUtils.js
+++ b/src/truffle-integration/projectFsWatcherUtils.js
@@ -1,9 +1,13 @@
 const path = require("path");
 
-export const getAncestorDirs = (truffle_directory, currDir, dirs = []) => {
+const getAncestorDirs = (truffle_directory, currDir, dirs = []) => {
   const parent = path.dirname(currDir);
 
   if (parent === currDir) return dirs;
   else if (parent === truffle_directory) return [parent, ...dirs];
   return getAncestorDirs(truffle_directory, parent, [parent, ...dirs]);
+};
+
+module.exports = {
+  getAncestorDirs,
 };

--- a/src/truffle-integration/projectFsWatcherUtils.js
+++ b/src/truffle-integration/projectFsWatcherUtils.js
@@ -2,9 +2,9 @@ const path = require("path");
 
 /**
  *
- * @param {*} truffle_directory The directory of your Truffle project
- * @param {*} currDir The current directory
- * @param {*} ancestorDirs The current array of ancestor dirs found
+ * @param {string} truffle_directory The directory of your Truffle project
+ * @param {string} currDir The current directory
+ * @param {string[]} ancestorDirs The current array of ancestor dirs found
  * @returns {string[]} An array of directory names which are ancestors to currDir
  */
 const getAncestorDirs = (truffle_directory, currDir, ancestorDirs = []) => {

--- a/src/truffle-integration/projectFsWatcherUtils.js
+++ b/src/truffle-integration/projectFsWatcherUtils.js
@@ -1,0 +1,9 @@
+const path = require("path");
+
+export const getAncestorDirs = (truffle_directory, currDir, dirs = []) => {
+  const parent = path.dirname(currDir);
+
+  if (parent === currDir) return dirs;
+  else if (parent === truffle_directory) return [parent, ...dirs];
+  return getAncestorDirs(truffle_directory, parent, [parent, ...dirs]);
+};

--- a/src/truffle-integration/projectFsWatcherUtils.js
+++ b/src/truffle-integration/projectFsWatcherUtils.js
@@ -1,11 +1,18 @@
 const path = require("path");
 
-const getAncestorDirs = (truffle_directory, currDir, dirs = []) => {
+/**
+ *
+ * @param {*} truffle_directory The directory of your Truffle project
+ * @param {*} currDir The current directory
+ * @param {*} ancestorDirs The current array of ancestor dirs found
+ * @returns {string[]} An array of directory names which are ancestors to currDir
+ */
+const getAncestorDirs = (truffle_directory, currDir, ancestorDirs = []) => {
   const parent = path.dirname(currDir);
 
-  if (parent === currDir) return dirs;
-  else if (parent === truffle_directory) return [parent, ...dirs];
-  return getAncestorDirs(truffle_directory, parent, [parent, ...dirs]);
+  if (parent === currDir) return ancestorDirs;
+  else if (parent === truffle_directory) return [parent, ...ancestorDirs];
+  return getAncestorDirs(truffle_directory, parent, [parent, ...ancestorDirs]);
 };
 
 module.exports = {


### PR DESCRIPTION
Fixes #1078 

This PR does the following:

1. Fixes `contracts_build_directory` needing to be a direct child of `build_directory` (which defaults to `./build`) to get a Truffle project to link.
1. Allows you to put your `contracts_build_directory` as deep as you want as a descendant of your Truffle project. (e.g. `path/to/project/a/b/c/d/contracts_build_directory`)
1. Allows you to put your `contracts_build_directory` outside of your Truffle project (i.e. not a descendant).

It does not do:

1. Handle the renaming of a contract in the directory. This seems like a current bug with Ganache. Currently in `develop` and this branch, if you rename a contract's file name, all other contracts in Ganache disappear. If you try to rename it back to the original name, nothing changes. I considered this out of scope, will open a new issue for this.
1. Subfolders of contract artifacts within `contracts_build_directory`. Didn't seem like it was in scope for this card. If enough people want it, then a new issue/feature request should be made.

FYI:

1. Does seem to be slightly slower than the current implementation, since I'm recursing through the chain of directories. My feeling is that most people will just have their `contracts_build_directory` inside their project anyways, so this shouldn't be too big of an issue, but if you think it is let me know.