### PR TITLE
Fix search for tx hash inside tx screen not working

### DIFF
--- a/src/renderer/screens/transactions/TxCard.js
+++ b/src/renderer/screens/transactions/TxCard.js
@@ -25,6 +25,13 @@ class TxCard extends Component {
     );
   }
 
+  componentDidUpdate(prevProps) {
+    const { transactionHash, dispatch } = this.props;
+    if (transactionHash !== prevProps.transactionHash) {
+      dispatch(Transactions.showTransaction(transactionHash));
+    }
+  }
+
   render() {
     const {
       currentTransaction: tx,


### PR DESCRIPTION
Fixes #298 

Has a side effect of the following:

1. Go inside a tx (call this tx 1)
1. Search for a different tx (tx 2) while on tx 1 screen.
1. Tx 2 screen will show
1. Pressing back button will take you to tx 1 screen.
1. Pressing back again will take you to tx list screen.

Not sure what the intended behaviour is here. Did we want to take people back to the full tx list on press of back button? @DiscRiskandBisque 

Regardless, I think that's a job for another issue, if this isn't the desired UX.