### PR TITLE
Fix/mac truffle link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7944,6 +7944,11 @@
         }
       }
     },
+    "default-shell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+      "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw="
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -12645,6 +12650,14 @@
       "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY=",
       "dev": true
     },
+    "fix-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fix-path/-/fix-path-2.1.0.tgz",
+      "integrity": "sha1-cuznOd6a9L1j/QLaI+mnDGGbTDg=",
+      "requires": {
+        "shell-path": "^2.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -13006,8 +13019,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -13028,14 +13040,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13050,20 +13060,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -13180,8 +13187,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -13193,7 +13199,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -13208,7 +13213,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -13222,7 +13226,6 @@
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -13321,8 +13324,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -13334,7 +13336,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13420,8 +13421,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13457,7 +13457,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13477,7 +13476,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13521,14 +13519,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -30325,6 +30321,58 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-env": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-0.3.0.tgz",
+      "integrity": "sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=",
+      "requires": {
+        "default-shell": "^1.0.0",
+        "execa": "^0.5.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "shell-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-2.1.0.tgz",
+      "integrity": "sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=",
+      "requires": {
+        "shell-env": "^0.3.0"
+      }
     },
     "shell-quote": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "ethereumjs-units": "^0.2.0",
     "filesize": "^3.6.1",
     "find-process": "^1.1.0",
+    "fix-path": "^2.1.0",
     "fs-extra": "^7.0.0",
     "ganache-core": "2.5.3",
     "keccak": "^1.4.0",

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6,6 +6,7 @@ import * as os from "os";
 import merge from "lodash.merge";
 import ethagen from "ethagen";
 import moniker from "moniker";
+import fixPath from "fix-path";
 
 const isDevMode = process.execPath.match(/[\\/]electron/) !== null;
 
@@ -84,6 +85,14 @@ process.on("unhandledRejection", err => {
 });
 
 app.setName("Ganache");
+
+// https://github.com/sindresorhus/fix-path
+// GUI apps on macOS don't inherit the $PATH defined in your dotfiles
+// i.e. opening app by clicking on icon in Finder, applications list screen
+// $PATH will be defined if you run from terminal (even in production) e.g: . /Applications/Ganache.app/Contents/MacOS/Ganache
+if (process.platform === "darwin") {
+  fixPath();
+}
 
 const getIconPath = () => {
   return process.platform === "win32"

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -87,7 +87,7 @@ process.on("unhandledRejection", err => {
 app.setName("Ganache");
 
 // https://github.com/sindresorhus/fix-path
-// GUI apps on macOS don't inherit the $PATH defined in your dotfiles
+// GUI apps on macOS don't inherit the $PATH defined in your dotfiles (.bashrc/.bash_profile/.zshrc/etc)
 // i.e. opening app by clicking on icon in Finder, applications list screen
 // $PATH will be defined if you run from terminal (even in production) e.g: . /Applications/Ganache.app/Contents/MacOS/Ganache
 if (process.platform === "darwin") {


### PR DESCRIPTION
Fixes #1160 

https://github.com/sindresorhus/fix-path
GUI apps on macOS don't inherit the `$PATH` defined in your dotfiles (`.bashrc`/`.bash_profile`/`.zshrc`/etc). This happens when you launch the app by clicking on icon in Finder or from the applications list screen.

`$PATH` will be defined if you run from terminal (even in production) e.g: 
```
. /Applications/Ganache.app/Contents/MacOS/Ganache
```
which was initially very confusing.

So the root problem wasn't production vs development, it was launching from terminal vs launching from the GUI. I suppose we should add these things to our test cases.