### PR TITLE
add retry logic by manually finding the node path for nvm

### DIFF
--- a/src/renderer/screens/contracts/ContractsScreen.js
+++ b/src/renderer/screens/contracts/ContractsScreen.js
@@ -30,8 +30,8 @@ class ContractsScreen extends Component {
               errorMessage = (
                 <span>
                   <strong>Your Truffle Project config is invalid.</strong> The
-                  file should be named either 'truffle.js' or
-                  'truffle-config.js'.{" "}
+                  file should be named either &quot;truffle.js&quot; or
+                  &quot;truffle-config.js&quot;.{" "}
                   <Link className="settingsLink" to="/config">
                     Choose a valid configuration file.
                   </Link>
@@ -42,7 +42,12 @@ class ContractsScreen extends Component {
             default: {
               errorMessage = (
                 <span>
-                  <strong>Unknown error:</strong> {project.error}
+                  <strong>Unhandled Error:</strong>
+                  <div>{project.error}</div>
+                  <Link className="settingsLink" to="/config">
+                    Check the project configuration
+                  </Link>{" "}
+                  or try restarting Ganache.
                 </span>
               );
               break;

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -23,7 +23,6 @@ async function getNodeVersionFromShell(shell, nvmDir) {
       return nodeVersion.trim();
     }
   } catch (e) {
-    throw e;
     // We throw the error away because we really only care if it worked or not
   }
   return null;

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -4,7 +4,46 @@ const child_process = require("child_process");
 const TruffleConfig = require("truffle-config");
 const temp = require("temp");
 
-async function get(projectFile) {
+const noNodeErrorMessage =
+  "Could not find 'node'. NodeJS is required to be installed to link Truffle projects.";
+
+async function attemptRetry(projectFile) {
+  const nvmDir = path.join(process.env.HOME, ".nvm");
+
+  if (fs.existsSync(nvmDir)) {
+    let shell;
+
+    if (fs.existsSync("/bin/bash")) {
+      shell = "/bin/bash";
+    } else if (fs.existsSync("/usr/bin/bash")) {
+      shell = "/usr/bin/bash";
+    } else {
+      throw new Error(noNodeErrorMessage);
+    }
+
+    process.env.NVM_DIR = nvmDir;
+    const nodeVersion = child_process
+      .execSync(
+        "source " +
+          path.join(nvmDir, "nvm.sh") +
+          " && nvm_resolve_local_alias default",
+        {
+          shell: shell,
+          encoding: "utf8",
+        },
+      )
+      .trim();
+
+    const nodeDir = path.join(nvmDir, "versions", "node", nodeVersion, "bin");
+    process.env.PATH = nodeDir + ":" + process.env.PATH;
+
+    return await get(projectFile, true);
+  } else {
+    throw new Error(noNodeErrorMessage);
+  }
+}
+
+async function get(projectFile, isRetry = false) {
   return new Promise(async (resolve, reject) => {
     try {
       const configFileDirectory = path.dirname(projectFile);
@@ -60,11 +99,14 @@ async function get(projectFile) {
         stdio: ["pipe", "pipe", "pipe", "ipc"],
       };
       const child = child_process.spawn("node", args, options);
-      child.on("error", error => {
+      child.on("error", async error => {
         if (error.code === "ENOENT") {
-          throw new Error(
-            "Could not find 'node'. NodeJS is required to be installed to link Truffle projects.",
-          );
+          // could not find node. check to see if they have ~/.nvm
+          if (!isRetry) {
+            resolve(await attemptRetry(projectFile));
+          } else {
+            throw new Error(noNodeErrorMessage);
+          }
         } else {
           throw new Error(error);
         }

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -13,7 +13,7 @@ async function getNodeVersionFromShell(shell, nvmDir) {
   try {
     const nvmPath = path.join(nvmDir, "nvm.sh");
     const nodeVersion = await exec(
-      `source ${nvmPath} && nvm_resolve_local_alias default`,
+      `unset npm_config_prefix && source ${nvmPath} && nvm_resolve_local_alias default`,
       {
         shell,
         encoding: "utf8",
@@ -112,11 +112,7 @@ async function get(projectFile, isRetry = false) {
       const options = {
         stdio: ["pipe", "pipe", "pipe", "ipc"],
       };
-      const child = child_process.spawn(
-        isRetry ? "node" : "failsssss",
-        args,
-        options,
-      );
+      const child = child_process.spawn("node", args, options);
       child.on("error", async error => {
         const response = {
           name: name,

--- a/src/truffle-integration/projectDetails.js
+++ b/src/truffle-integration/projectDetails.js
@@ -11,10 +11,9 @@ const noNodeErrorMessage =
 
 async function getNodeVersionFromShell(shell, nvmDir) {
   try {
-    let nodeVersion = await exec(
-      "source " +
-        path.join(nvmDir, "nvm.sh") +
-        " && nvm_resolve_local_alias default",
+    const nvmPath = path.join(nvmDir, "nvm.sh");
+    const nodeVersion = await exec(
+      `source ${nvmPath} && nvm_resolve_local_alias default`,
       {
         shell,
         encoding: "utf8",
@@ -24,6 +23,7 @@ async function getNodeVersionFromShell(shell, nvmDir) {
       return nodeVersion.trim();
     }
   } catch (e) {
+    throw e;
     // We throw the error away because we really only care if it worked or not
   }
   return null;
@@ -112,7 +112,11 @@ async function get(projectFile, isRetry = false) {
       const options = {
         stdio: ["pipe", "pipe", "pipe", "ipc"],
       };
-      const child = child_process.spawn("node", args, options);
+      const child = child_process.spawn(
+        isRetry ? "node" : "failsssss",
+        args,
+        options,
+      );
       child.on("error", async error => {
         const response = {
           name: name,


### PR DESCRIPTION
Fixes #1165 by loading the `~/.nvm/nvm.sh` script in a `bash` shell session to get the default node version. It then adds `~/.nvm/versions/node/${version}/bin` to `process.env.PATH` and tries to load the project again. It only retries once.