### PR TITLE
Changes that allow connecting to an external standalone node (non-ganache node)

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -301,12 +301,12 @@ app.on("ready", () => {
       chain.on("server-started", data => {
         if (workspace) {
           mainWindow.webContents.send(SET_KEY_DATA, {
-            privateKeys: data.privateKeys,
-            mnemonic: data.mnemonic,
-            hdPath: data.hdPath,
+            privateKeys: data.privateKeys || "",
+            mnemonic: data.mnemonic || "",
+            hdPath: data.hdPath || "",
           });
 
-          workspace.settings.handleNewMnemonic(data.mnemonic);
+          workspace.settings.handleNewMnemonic(data.mnemonic || "");
 
           const globalSettings = global.getAll();
           const workspaceSettings = workspace.settings.getAll();

--- a/src/main/types/settings/WorkspaceSettings.js
+++ b/src/main/types/settings/WorkspaceSettings.js
@@ -26,6 +26,13 @@ const initialSettings = {
     hardfork: "petersburg",
   },
   projects: [],
+  regtest: {
+    name: "RSK Regtest",
+    hostname: "127.0.0.1",
+    port: 4445,
+    network_id: 7771,
+    suffix: "/websocket"
+  }
 };
 
 class WorkspaceSettings extends Settings {

--- a/src/renderer/init/Core.js
+++ b/src/renderer/init/Core.js
@@ -35,13 +35,24 @@ export function initCore(store) {
   ipcRenderer.on(
     SET_SERVER_STARTED,
     (sender, globalSettings, workspaceSettings, startupMode) => {
+      if (workspaceSettings.server.regtest && workspaceSettings.regtest) {
+          workspaceSettings.server.hostname = workspaceSettings.regtest.hostname;
+          workspaceSettings.server.port = workspaceSettings.regtest.port;
+          workspaceSettings.name = workspaceSettings.regtest.name;
+      }
+
+      const suffix = workspaceSettings.regtest && workspaceSettings.regtest.suffix
+                      ? workspaceSettings.regtest.suffix
+                      : "";
+
       // Get current settings into the store
       store.dispatch(setSettings(globalSettings, workspaceSettings));
 
       // Ensure web3 is set
       const url = `ws://${workspaceSettings.server.hostname}:${
         workspaceSettings.server.port
-      }`;
+      }` + suffix;
+
       ipcRenderer.send("web3-provider", url);
       store.dispatch(setRPCProviderUrl(url));
 

--- a/src/renderer/screens/config/ConfigScreens/ServerScreen.js
+++ b/src/renderer/screens/config/ConfigScreens/ServerScreen.js
@@ -31,6 +31,8 @@ class ServerScreen extends Component {
     this.state = {
       automine:
         typeof props.config.settings.workspace.server.blockTime == "undefined",
+      regtest:
+        props.config.settings.workspace.server.regtest || false
     };
   }
 
@@ -62,6 +64,15 @@ class ServerScreen extends Component {
 
     this.setState({
       automine: !this.state.automine,
+    });
+  };
+
+  toggleRegtest = () => {
+    var newValue = !this.state.regtest;
+    this.props.config.settings.workspace.server.regtest = newValue;
+
+    this.setState({
+      regtest: !this.state.regtest,
     });
   };
 
@@ -219,6 +230,27 @@ class ServerScreen extends Component {
             </div>
             <div className="RowItem">
               <p>Process transactions instantaneously.</p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h4>REGTEST</h4>
+          <div className="Row">
+            <div className="RowItem">
+              <div className="Switch">
+                <input
+                  type="checkbox"
+                  name="regtest"
+                  id="Regtest"
+                  onChange={this.toggleRegtest}
+                  checked={this.state.regtest}
+                />
+                <label htmlFor="Regtest">REGTEST ENABLED</label>
+              </div>
+            </div>
+            <div className="RowItem">
+              <p>Connect to non-ganache node.</p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
This PR is a first approach of a proposal for #1229 

The idea is this:
- You should have an external regtest node running.
- You can set a flag in server configuration that enables "Regtest" mode. With this flag in `true`, ganache server is not launched.
- With regtest mode in `true`, you can set the external node port in server config screen (and avoid the "port in use" error).
- You can add a `regtest` configuration that is used in case you launch a "Quickstart" workspace.

Some considerations:
- I tried this solution against an RSK node, that has some particularities (i.e. `/websocket` in socket connection url, `newHeads` subscription that needed a different approach to make it work, etc)
- This proposal is a first approach that would be improved to get a more elegant solution. 

