### PR TITLE
v2.0.0 is no longer "the latest update"

### DIFF
--- a/src/renderer/screens/startup/HomeScreen.js
+++ b/src/renderer/screens/startup/HomeScreen.js
@@ -106,7 +106,7 @@ class HomeScreen extends Component {
     const learnMore = (
       <p className="learnMoreText">
         <a href="https://github.com/trufflesuite/ganache/releases/tag/v2.0.0">
-          Learn more about the latest update!
+          Learn more about the update to version 2!
         </a>
       </p>
     );


### PR DESCRIPTION
Keeping the link to the explanation of major changes is probably more useful than changing the link to the latest patch changelog, so this updates the link text instead, for accuracy.
