### PR TITLE
Do not limit local storage size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25640,9 +25640,9 @@
       "dev": true
     },
     "node-localstorage": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
-      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.1.5.tgz",
+      "integrity": "sha512-DMmdnUxGbDg/vKECZv+4SU3OMKo+TieRNbjncttxEo92IgJIpBfxQJHfD5Oz4nwTYajW4De1wyL9O4HcWeZ90Q==",
       "requires": {
         "write-file-atomic": "^1.1.4"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",
     "moniker": "^0.1.2",
-    "node-localstorage": "^1.3.1",
+    "node-localstorage": "^2.1.5",
     "pluralize": "^5.0.0",
     "react": "^16.9.0",
     "react-custom-scrollbars": "^4.2.1",

--- a/src/main/types/json/JsonStorage.js
+++ b/src/main/types/json/JsonStorage.js
@@ -11,7 +11,7 @@ class JsonStorage {
 
   setStorageDirectory(directory) {
     this.directory = directory;
-    this.storage = new LocalStorage(this.directory);
+    this.storage = new LocalStorage(this.directory, Number.MAX_VALUE);
   }
 
   getFromStorage() {


### PR DESCRIPTION
The package node-localstorage limits quota (default 5MB). This quota limitation is coming from the localStorage implementation in the browsers.

While working with larger datasets and lots of transactions, you will encounter QUOTA_EXCEEDED_ERR exceptions when working with Ganache.

By overriding the quota limit to Number.MAX_VALUE we can work with big amounts of transactions.