### PR TITLE
Fix #1560 - show config screen when port-bind errors occur on startup

### DIFF
--- a/src/integrations/corda/main/utils/network/corda.js
+++ b/src/integrations/corda/main/utils/network/corda.js
@@ -89,6 +89,9 @@ class Corda {
    * @param {*} failedStartup set to `true` if stop should be called without waiting for startup.
    */
   async stop(failedStartup = false) {
+    // make sure us stopping a node early doesn't trigger an early close error
+    this.java && this.java.off("earlyCloseHandler", this.earlyCloseHandler);
+
     // if we are currently starting up, wait for that to finish before attempting to stop
     if (!failedStartup && this.status === "starting") {
       await this._startPromise
@@ -149,7 +152,7 @@ class Corda {
         if (this.shell) {
           await this.shell.disconnect();
         }
-        this.ssh.gracefulShutdown(this.kill);
+        this.ssh.gracefulShutdown(this.kill.bind(this, java));
       } else {
         // somehow we got here without an ssh connection, which is weird, but
         // technically possible if we DID have a connection that soon failed.
@@ -284,18 +287,23 @@ class Corda {
     return true;
   }
 
-  async handlePortBindError() {
+  async handlePortBindError(data) {
     const reject = this._awaiter.reject;
+     // We're goin to reject soon enough.
+     // so make rejection a `noop` if anything else fails before we do
+    this._awaiter.reject = noop;
     
     this.java.off("close", this.earlyCloseHandler);
-    this.stop(true).then(() => {
-      const error = new Error("There was a port issue!");
-      error.code = "CUSTOMERROR";
-      error.tab = "nodes";
-      error.key = "nodes.nodeConfig";
-      error.value = "Could not start Corda nodes - a port is already in use. Fix conflict or edit node configuration before restarting.";
-      reject(error);
-    })
+    this
+      .stop(true)
+      .catch(noop).then(() => {
+        const error = new Error("There was a port issue!");
+        error.code = "CUSTOMERROR";
+        error.tab = "nodes";
+        error.key = "nodes.nodeConfig";
+        error.value = `Could not start Corda node ${this.entity.safeName} - a port is already in use. Fix conflict or edit node configuration before restarting. Details: \n${data.toString().trim()}`;
+        reject(error);
+      });
     return true;
   }
 }

--- a/src/integrations/corda/main/utils/network/corda.js
+++ b/src/integrations/corda/main/utils/network/corda.js
@@ -232,6 +232,7 @@ class Corda {
           this._shellProm.then(shell => shell && shell.resize(this.shellDimensions));
         }
       }).catch((reason) => {
+        // eslint-disable-next-line no-console
         console.log(reason);
       });
     }
@@ -283,12 +284,17 @@ class Corda {
     return true;
   }
 
-  async handlePortBindError(data) {
+  async handlePortBindError() {
     const reject = this._awaiter.reject;
     
     this.java.off("close", this.earlyCloseHandler);
     this.stop(true).then(() => {
-      reject(new Error(data.toString().trim()));
+      const error = new Error("There was a port issue!");
+      error.code = "CUSTOMERROR";
+      error.tab = "nodes";
+      error.key = "nodes.nodeConfig";
+      error.value = "Could not start Corda nodes - a port is already in use. Fix conflict or edit node configuration before restarting.";
+      reject(error);
     })
     return true;
   }

--- a/src/integrations/corda/main/utils/network/manager.js
+++ b/src/integrations/corda/main/utils/network/manager.js
@@ -222,14 +222,12 @@ class NetworkManager extends EventEmitter {
         // eslint-disable-next-line require-atomic-updates
         entity.braidPort = await this.getPort(entity.rpcPort + 10000);
         if (this.cancelled) return;
-        const braidPromise = this.braid.start(entity, currentPath, JAVA_HOME);
+        await this.braid.start(entity, currentPath, JAVA_HOME);
         const corda = new Corda(entity, currentPath, JAVA_HOME, this._io);
         this.processes.push(corda);
-        const cordaProm = corda.start();
-        cordaProm.then(() => {
+        await corda.start().then(() => {
           this._io.sendProgress(`Corda node ${++startedNodes}/${entities.length} online...`);
         });
-        await Promise.all([cordaProm, braidPromise]);
         if (this.cancelled) return;
         // we need to get the `owningKey` for this node so we can reference it in the front end
         // eslint-disable-next-line require-atomic-updates

--- a/src/integrations/corda/main/utils/network/manager.js
+++ b/src/integrations/corda/main/utils/network/manager.js
@@ -208,7 +208,6 @@ class NetworkManager extends EventEmitter {
   }
 
   async start() {
-    try {
       const chaindataDir = await this.chaindataDirectory;
       const entities = this.entities;
       this._io.sendProgress("Loading JRE...");
@@ -222,12 +221,13 @@ class NetworkManager extends EventEmitter {
         // eslint-disable-next-line require-atomic-updates
         entity.braidPort = await this.getPort(entity.rpcPort + 10000);
         if (this.cancelled) return;
-        await this.braid.start(entity, currentPath, JAVA_HOME);
+        const braidPromise = this.braid.start(entity, currentPath, JAVA_HOME);
         const corda = new Corda(entity, currentPath, JAVA_HOME, this._io);
         this.processes.push(corda);
-        await corda.start().then(() => {
+        const cordaProm = corda.start().then(() => {
           this._io.sendProgress(`Corda node ${++startedNodes}/${entities.length} online...`);
         });
+        await Promise.all([cordaProm, braidPromise]);
         if (this.cancelled) return;
         // we need to get the `owningKey` for this node so we can reference it in the front end
         // eslint-disable-next-line require-atomic-updates
@@ -236,18 +236,13 @@ class NetworkManager extends EventEmitter {
           .then(self => self.legalIdentities[0].owningKey);
       });
 
-      await Promise.all(promises);
-      if (this.cancelled) return;
+    await Promise.all(promises);
+    if (this.cancelled) return;
 
-      // _downloadPromise was started long ago, we just need to make sure all
-      //  deps are downloaded before we start up.
-      this._io.sendProgress(`Downloading remaining Corda dependencies...`, 0);
-      this.blobInspector = new BlobInspector(JAVA_HOME, await this.config.corda.files.blobInspector.download());
-    } catch (e) {
-      await this.stop();
-      
-      throw e;
-    }
+    // _downloadPromise was started long ago, we just need to make sure all
+    //  deps are downloaded before we start up.
+    this._io.sendProgress(`Downloading remaining Corda dependencies...`, 0);
+    this.blobInspector = new BlobInspector(JAVA_HOME, await this.config.corda.files.blobInspector.download());
   }
 
   async stop() {

--- a/src/integrations/corda/renderer/screens/config/ConfigScreens/NodesScreen.js
+++ b/src/integrations/corda/renderer/screens/config/ConfigScreens/NodesScreen.js
@@ -225,6 +225,11 @@ class NodesScreen extends Component {
         <section>
           <p>Note: Recommended maximum number of Nodes + Notaries for your current hardware is {Math.min(ARBITRARY_MAXIMUM_NODES, Math.max(3, navigator.hardwareConcurrency - 2))}.</p>
           <br />
+          {this.props.config.validationErrors["nodes.nodeConfig"] && (
+            <p className="ValidationError">
+              {this.props.config.validationErrors["nodes.nodeConfig"]}
+            </p>
+          )}
           <div className="WorkspaceProjects">
             <div className="projectItemContainer">
               {

--- a/src/integrations/index.js
+++ b/src/integrations/index.js
@@ -85,13 +85,13 @@ class IntegrationManager extends EventEmitter {
 
   async startChain() {
     if (this.flavor) {
-      await this.flavor.start();
+      return this.flavor.start();
     }
   }
 
   async stopChain() {
     if (this.flavor) {
-      await this.flavor.stop();
+      return this.flavor.stop();
     }
   }
 
@@ -104,8 +104,10 @@ class IntegrationManager extends EventEmitter {
         this.workspace.settings.setAll(settings);
   
         this.emit("server-started");
+        return true;
       } catch (e) {
-        this.emit('error', e);
+        this.emit("error", e);
+        return false;
       }
     }
   }

--- a/src/integrations/index.js
+++ b/src/integrations/index.js
@@ -98,11 +98,15 @@ class IntegrationManager extends EventEmitter {
   async startServer() {
     if (this.flavor && this.workspace) {
       const settings = this.workspace.settings.getAll();
-      await this.flavor.startServer(settings, this.workspace.workspaceDirectory);
-      // just incase startServer mutates the settings (corda does), save them
-      this.workspace.settings.setAll(settings);
-
-      this.emit("server-started");
+      try {
+        await this.flavor.startServer(settings, this.workspace.workspaceDirectory);
+        // just incase startServer mutates the settings (corda does), save them
+        this.workspace.settings.setAll(settings);
+  
+        this.emit("server-started");
+      } catch (e) {
+        this.emit('error', e);
+      }
     }
   }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -486,11 +486,11 @@ app.on('ready', () => {
     );
 
     startupMode = STARTUP_MODE.NORMAL;
-    await integrations.startServer();
-
-    // this sends the network interfaces to the renderer process for
-    //  enumering in the config screen. it sends repeatedly
-    continuouslySendNetworkInterfaces();
+    if (await integrations.startServer()){
+      // this sends the network interfaces to the renderer process for
+      //  enumering in the config screen. it sends repeatedly
+      continuouslySendNetworkInterfaces();
+    }
   });
 
   ipcMain.on(OPEN_NEW_WORKSPACE_CONFIG, async (_event, flavor = "ethereum") => {
@@ -526,7 +526,9 @@ app.on('ready', () => {
     startupMode = STARTUP_MODE.NEW_WORKSPACE;
     if (flavor === "ethereum") {
       await integrations.startChain();
-      await integrations.startServer();
+      if (!(await integrations.startServer())) {
+        return;
+      }
     } else {
       if (workspace) {
         const globalSettings = global.getAll();
@@ -613,10 +615,10 @@ app.on('ready', () => {
 
       startupMode = STARTUP_MODE.NORMAL;
 
-      await integrations.startServer();
-
-      // send the interfaces again once on restart
-      sendNetworkInterfaces();
+      if (await integrations.startServer()){
+        // send the interfaces again once on restart
+        sendNetworkInterfaces();
+      }
     }
   });
 

--- a/src/renderer/routes.js
+++ b/src/renderer/routes.js
@@ -49,6 +49,8 @@ class FlavorRoutes extends Component {
           component={EventDetailsScreen}
         />
         <Route path="/notfound" component={NotFoundScreen} />
+        
+        <Route path="/config/corda/:activeTab?" component={ConfigScreen} />
         <Route path="/config/:activeTab?" component={ConfigScreen} />
 
         <Route exact path="/corda">

--- a/src/renderer/screens/config/ConfigScreen.js
+++ b/src/renderer/screens/config/ConfigScreen.js
@@ -76,10 +76,14 @@ class ConfigScreen extends PureComponent {
   }
 
   initActiveIndex = () => {
-    if ("params" in this.props && "activeTab" in this.props.match.params) {
+    if ("params" in this.props.match && "activeTab" in this.props.match.params) {
       const TABS = this.state.TABS
       for (let i = 0; i < TABS.length; i++) {
-        if (TABS[i].subRoute === this.props.match.params.activeTab) {
+        // Get the tab name, no matter if the subroute has a flavor prefix.
+        let subRoute = TABS[i].subRoute;
+        let tabName = subRoute.substring(subRoute.indexOf("/") + 1);
+
+        if (tabName === this.props.match.params.activeTab) {
           // eslint-disable-next-line react/no-direct-mutation-state
           this.state.activeIndex = i;
           break;


### PR DESCRIPTION
This PR fixes #1560. 

![image](https://user-images.githubusercontent.com/92629/77735683-3c0f4f00-6fc8-11ea-84d1-4612b0334840.png)

This fix required more changes than I expected, so I wanted to quickly detail a few of the items:

https://github.com/trufflesuite/ganache/blob/da8bfa26ee7d03860b60fb1d826810a5b186f96e/src/integrations/corda/main/utils/network/corda.js#L292-L297

This change in `corda.js` defines the data necessary to trigger actions on the frontend, after the error gets bubbled all the way up. The important items are the `tab`, `key`, and `value`:

- `tab` is the route name of the Config tab that you want to be active when the error is shown. In the case where the route name of the tab has a slash, like `corda/nodes`, use the suffix `nodes`. (This is important in the tab detection discussed below.)
- `key` is an arbitrary key that the specific Config screen is set to show, if a validation error with that key is set. The frontend's error handling system will flag this key with the error, and the associated screen will show it if it exists. The value of `key` is arbitrary; the key defined in the error and the key the screen looks for has to match.
- `value` is the error message that ultimately gets displayed. That said, the frontend is not required to display this error message, but usually the screens are configured to do so.

-----------

https://github.com/trufflesuite/ganache/blob/96874c66880dd244cde6e73c57ce8568f0b82237/src/integrations/corda/main/utils/network/manager.js#L225-L230

This change in `manager.js` starts the braid and corda services in series instead of in parallel, so that the code has proper error handling. The previous version of this code executed promises without immediately `await`'ing them, which caused the error to be handled outside of the async function's promise rejection. By explicitly awaiting each item, we know the error will be handled properly. There might be a better way here to add parallelism back in, but I left that as something that could be done later.

-----------

https://github.com/trufflesuite/ganache/blob/a15ebbd8e2f2f4d3d4850fd3abab301908bbc4ca/src/renderer/routes.js#L53-L54

https://github.com/trufflesuite/ganache/blob/f5fd4a2d4cd69ac377cafb7dcd1c07ac130b5daf/src/renderer/screens/config/ConfigScreen.js#L79-L84

These two changes I'm not so happy with, but this seemed like the most straightforward. Because Corda's config screen routes have a forward slash in them, as seen [here](https://github.com/trufflesuite/ganache/blob/f5fd4a2d4cd69ac377cafb7dcd1c07ac130b5daf/src/renderer/screens/config/ConfigScreen.js#L41-L46), the active tab detection in `ConfigScreen.js` wasn't working when an error message requested a Corda config screen to be active. This is because the original route would interpret `corda` as being the active tab, since `path="/config/:activeTab?"` would match `corda` when the route requested is `/config/corda/nodes`. To get around this, I added a new route for Corda config screens that has priority over the previous route, and hardcodes the flavor prefix so `:activeTab` gets set correctly. I then changed the tab detection code to ignore the flavor prefix if it existed in the tab's route. Good news here is the tab detection should work the same if no flavor prefix exists in the tab's route (e.g., Ethereum). I contemplated removing changing the corda config screens so that they didn't have a slash, and so they had a single unique name, but that seemed likely to cause more (route) issues than it solved.