### PR TITLE
fix: don't crash if OSX's .DS_Store dir exists

### DIFF
--- a/src/main/types/workspaces/WorkspaceManager.js
+++ b/src/main/types/workspaces/WorkspaceManager.js
@@ -18,6 +18,12 @@ class WorkspaceManager {
           if (!fse.lstatSync(path.join(workspacesDirectory, file)).isDirectory) {
             return [];
           }
+          // if an osx user navigates to the workspaces directory osx will put a
+          // .DS_Store folder there, ignore these.
+          if (file === ".DS_Store") {
+            return []
+          }
+
           let settings = new WorkspaceSettings(
             path.join(workspacesDirectory, file),
             path.join(workspacesDirectory, file, "chaindata"),


### PR DESCRIPTION
fixes #2018
fixes #2006
fixes #2000
fixes #1867
fixes #1758