### PR TITLE
fix(windows): fix appx install on non-OS drive

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -94,6 +94,12 @@ if (process.platform === "win32") {
     .then(()=> {
       return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "workspaces")])
     })
+    .then(()=> {
+      return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "default")])
+    })
+    .then(()=> {
+      return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "global")])
+    })
     .catch(e => { console.error(e) });
 
   // start a migration, if needed


### PR DESCRIPTION
fixes #2057
fixes #2055
fixes #2050
fixes #2048
fixes #2036
fixes #1985
fixes #1971
fixes #1960
fixes #1950
fixes #1944
fixes #1909
fixes #1897
fixes #1880
fixes #1839
fixes #1834
fixes #1817
fixes #1776
fixes #1767

