### PR TITLE
Enable .cjs config files on ESM projects -  FIX: #2881

### DIFF
--- a/src/integrations/ethereum/renderer/screens/config/ConfigScreens/WorkspaceScreen.js
+++ b/src/integrations/ethereum/renderer/screens/config/ConfigScreens/WorkspaceScreen.js
@@ -7,11 +7,11 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 class WorkspaceScreen extends Component {
   state = { selectedIdx: null };
 
-  validateChange = e => {
+  validateChange = (e) => {
     this.props.validateChange(e, {});
   };
 
-  handleProjectClick = idx => () => {
+  handleProjectClick = (idx) => () => {
     this.setState({
       selectedIdx: this.state.selectedIdx === idx ? null : idx,
     });
@@ -20,30 +20,30 @@ class WorkspaceScreen extends Component {
   handleAddProjectClick = async () => {
     const pathArray = await remote.dialog.showOpenDialog({
       properties: ["openFile"],
-      filters: [{ name: "Truffle Config File", extensions: ["js"] }],
+      filters: [{ name: "Truffle Config File", extensions: ["js", "cjs"] }],
     });
 
     if (
       pathArray &&
       pathArray.filePaths.length > 0 &&
-      path.basename(pathArray.filePaths[0]).match(/^truffle(-config)?.js$/)
+      path.basename(pathArray.filePaths[0]).match(/^truffle(-config)?.[c]?js$/)
     ) {
       this.props.addWorkspaceProject(pathArray.filePaths[0]);
       this.setState({ selectedIdx: null });
     }
   };
 
-  removeProject = projectPath => {
+  removeProject = (projectPath) => {
     this.props.removeWorkspaceProject(projectPath);
     this.setState({ selectedIdx: null });
   };
 
-  verifyRemoveProject = projectPath => {
+  verifyRemoveProject = (projectPath) => {
     const modalDetails = new ModalDetails(
       ModalDetails.types.WARNING,
       [
         {
-          click: modal => {
+          click: (modal) => {
             this.removeProject(projectPath);
             modal.close();
           },
@@ -54,7 +54,7 @@ class WorkspaceScreen extends Component {
         },
       ],
       "Remove Project?",
-      "This project has contracts deployed; are you sure you want to remove it? Contract data, transactions, and events will no longer be decoded.",
+      "This project has contracts deployed; are you sure you want to remove it? Contract data, transactions, and events will no longer be decoded."
     );
 
     this.props.dispatch(ModalDetails.actions.setModalError(modalDetails));
@@ -67,7 +67,7 @@ class WorkspaceScreen extends Component {
 
     let projectHasDeployedContracts = false;
 
-    let project = this.props.workspaces.current.projects.filter(project => {
+    let project = this.props.workspaces.current.projects.filter((project) => {
       return path.dirname(projectPath) === project.configFile;
     });
 
@@ -83,7 +83,7 @@ class WorkspaceScreen extends Component {
                 contract.address.length > 0)
             );
           },
-          false,
+          false
         );
       }
     }
@@ -140,7 +140,9 @@ class WorkspaceScreen extends Component {
                     {showErrorDetails && (
                       <div className="ValidationDetails">
                         <SyntaxHighlighter language="bash">
-                          {validationErrors.stack.map(line => line.toString())}
+                          {validationErrors.stack.map((line) =>
+                            line.toString()
+                          )}
                         </SyntaxHighlighter>
                       </div>
                     )}
@@ -183,7 +185,8 @@ class WorkspaceScreen extends Component {
             <div className="RowItem">
               <p>
                 Link Truffle projects to this workspace by adding their
-                truffle-config.js or truffle.js file to this workspace.
+                truffle-config.js, truffle-config.cjs, truffle.js or truffle.cjs
+                file to this workspace.
               </p>
               <br />
               <p>

--- a/src/integrations/ethereum/renderer/screens/contracts/ContractsScreen.js
+++ b/src/integrations/ethereum/renderer/screens/contracts/ContractsScreen.js
@@ -31,8 +31,9 @@ class ContractsScreen extends Component {
               errorMessage = (
                 <span>
                   <strong>Your Truffle Project config is invalid.</strong> The
-                  file should be named either &quot;truffle.js&quot; or
-                  &quot;truffle-config.js&quot;.{" "}
+                  file should be named either &quot;truffle.js&quot;,
+                  &quot;truffle.cjs&quot;, &quot;truffle-config.js&quot; or
+                  &quot;truffle-config.cjs&quot;.{" "}
                   <Link className="settingsLink" to="/config">
                     Choose a valid configuration file.
                   </Link>
@@ -105,7 +106,4 @@ class ContractsScreen extends Component {
   }
 }
 
-export default connect(
-  ContractsScreen,
-  "workspaces",
-);
+export default connect(ContractsScreen, "workspaces");

--- a/static/node/truffle-integration/projectsWatcher.js
+++ b/static/node/truffle-integration/projectsWatcher.js
@@ -158,7 +158,7 @@ class ProjectsWatcher extends EventEmitter {
     // TODO: might be an easier way now
     let truffleDirectory = projectPath;
     if (
-      path.basename(truffleDirectory).match(/truffle(-config)?.js/) !== null
+      path.basename(truffleDirectory).match(/truffle(-config)?.[c]?js/) !== null
     ) {
       truffleDirectory = path.dirname(truffleDirectory);
     }

--- a/static/node/truffle-project-loader/index.js
+++ b/static/node/truffle-project-loader/index.js
@@ -20,7 +20,7 @@ if (!fs.existsSync(projectFile)) {
     error: "project-does-not-exist",
   });
 } else if (
-  path.basename(projectFile).match(/^truffle(-config)?.js$/) === null
+  path.basename(projectFile).match(/^truffle(-config)?.[c]?js$/) === null
 ) {
   process.send({
     name,


### PR DESCRIPTION
Enable support for `.cjs` truffle config files, so it can be used on ESM (`{ "type": "module" }`) projects.

## Ganache

Before opening a pull request, please ensure:

- [X] You have followed our [**contributing guidelines**](https://github.com/trufflesuite/ganache/blob/master/.github/CONTRIBUTING.md)
- [N/A ] Pull request has tests
- [X] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch via a Pull Request, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/trufflesuite/ganache/blob/master/LICENSE.md).
