### PR TITLE
https://github.com/trufflesuite/ganache/actions/workflows/puRevert to using keystream when reading from metadata database

### DIFF
--- a/src/chains/ethereum/ethereum/src/forking/trie.ts
+++ b/src/chains/ethereum/ethereum/src/forking/trie.ts
@@ -89,14 +89,14 @@ export class ForkTrie extends GanacheTrie {
     endBlockNumber: Quantity
   ) {
     const db = this.metadataDB;
-    const stream = db.createReadStream({
+    const stream = db.createKeyStream({
       gte: lexico.encode([startBlockNumber.toBuffer()]),
       lt: lexico.encode([
         Quantity.from(endBlockNumber.toBigInt() + 1n).toBuffer()
       ])
     });
     const batch = db.batch();
-    for await (const [key] of stream) {
+    for await (const key of stream) {
       batch.del(key);
     }
     await batch.write();


### PR DESCRIPTION
[![Commits](https://github.com/trufflesuite/ganache/actions/workflows/push.yml/badge.svg)](https://github.com/trufflesuite/ganache/actions/workflows/push.yml)